### PR TITLE
Inform approved rejected application - 2

### DIFF
--- a/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -4,7 +4,7 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:omit-tag="textual">
 <head tal:omit-tag="textual">
-    <title tal:omit-tag="textual" >Deine Bewerbung für die <span tal:replace="domain_name">Site Name</span> wurde genehmigt</title>
+    <title tal:omit-tag="textual" >Deine Bewerbung an der Plattform von <span tal:replace="domain_name">Site Name</span> wurde genehmigt</title>
 </head>
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">Glückwunsch zur Genehmigung deines Antrags!</h1>

--- a/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,7 +17,7 @@
     
     <p tal:omit-tag="textual">Nachdem dein Antrag genehmigt wurde, kannst du dich mit dem Pseudonym und dem Passwort, das du während des Antragsverfahrens angegeben hast, auf unserer Plattform anmelden. Nach der Anmeldung findest du:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">die Links zu allen Softwareanwendungen, auf die du direkt zugreifen kannst. Du musst dich nicht erneut anmelden! Besuche vorrangig unseren <a href="https://workspace.<span tal:replace="domain_name„>Domainname</span>">Arbeitsbereich</a>, wo der Großteil unserer Aktivitäten stattfindet;</li>
+        <li tal:omit-tag="textual">die Links zu allen Softwareanwendungen, auf die du direkt zugreifen kannst. Du musst dich nicht erneut anmelden! Besuche vorrangig unseren <a tal:attributes="href string:https://workspace.${domain_name}">Arbeitsbereich</a>, wo der Großteil unserer Aktivitäten stattfindet;</li>
         <li tal:omit-tag="textual">ein Link zu dem Formular, in dem du dein eigenes Profil anzeigen und bearbeiten kannst. In diesem Formular kannst du dich den anderen Mitgliedern unserer Gemeinschaft in einem kurzen „Profiltext" vorstellen;</li>
         <li tal:omit-tag="textual">einen Link zum Abmelden.</li>
     </ul>

--- a/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,11 +17,11 @@
     
     <p tal:omit-tag="textual">Nachdem dein Antrag genehmigt wurde, kannst du dich mit dem Pseudonym und dem Passwort, das du während des Antragsverfahrens angegeben hast, auf unserer Plattform anmelden. Nach der Anmeldung findest du:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">die Links zu allen Softwareanwendungen, auf die du direkt zugreifen kannst. Du musst dich nicht erneut anmelden! Besuche vorrangig unseren <a tal:attributes="href string:https://workspace.${domain_name}">Arbeitsbereich</a>, wo der Großteil unserer Aktivitäten stattfindet;</li>
-        <li tal:omit-tag="textual">ein Link zu dem Formular, in dem du dein eigenes Profil anzeigen und bearbeiten kannst. In diesem Formular kannst du dich den anderen Mitgliedern unserer Gemeinschaft in einem kurzen „Profiltext" vorstellen;</li>
+        <li tal:omit-tag="textual">die Links zu allen Softwareanwendungen, auf die du direkt zugreifen kannst. Du musst dich nicht erneut anmelden! Besuche vorrangig unseren <a href="https://workspace.cosmopolitical.coop/login">Arbeitsbereich</a>, wo der Großteil unserer Aktivitäten stattfindet;</li>
+        <li tal:omit-tag="textual">ein Link zu dem Formular, in dem du dein eigenes Profil anzeigen und bearbeiten kannst. In diesem Formular kannst du dich den anderen Mitgliedern unserer Gemeinschaft in einem kurzen "Profiltext" vorstellen;</li>
         <li tal:omit-tag="textual">einen Link zum Abmelden.</li>
     </ul>
-
+     <p tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR"> <strong>Vergiss nicht!</strong> Um alle deine Rechte als Genossenschaftler wahrnehmen zu können – und insbesondere um stimmberechtigt zu sein – musst du: (1) <a href="https://www.cosmopolitical.coop/Share">mindestens einen Genossenschaftsanteil</a> erwerben und (2) <a href="https://www.cosmopolitical.coop/YearContrib">deinen Jahresbeitrag</a> bezahlen. Erledige das so schnell wie möglich!</p>
     <p tal:omit-tag="textual">Hier sind die wichtigsten Elemente deines Profils, die wir erfasst haben:</p>
     <ul tal:omit-tag="textual">
         <li tal:omit-tag="textual">dein Pseudonym: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Bitte bewahre dieses Pseudonym sorgfältig und sicher auf: Es ist die Kennung, die du während deiner gesamten Tätigkeit auf unserer IT-Plattform verwenden wirst;</li>

--- a/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -9,39 +9,39 @@
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">Glückwunsch zur Genehmigung deines Antrags!</h1>
     
-    <p tal:omit-tag="textual">Hallo <span tal:replace="user" tal:condition="exists:user">Name des Antragstellers</span>,</p>
+    <p tal:omit-tag="textual">Hallo <span tal:replace="python:candidature.pseudonym">pseudonym</span>,</p>
     
-    <p tal:omit-tag="textual">Wir freuen uns, dir mitzuteilen, dass deine Bewerbung an der <span tal:replace="domain_name">Site name</span> für die Rolle der <span tal:replace="python:candidature.type">Rolle</span> genehmigt wurde.</p>
+    <p tal:omit-tag="textual">Wir freuen uns, dir mitzuteilen, dass deine Bewerbung an der Plattform von <span tal:replace="domain_name">Site name</span> für die Rolle der <span tal:replace="python:candidature.type">Rolle</span> genehmigt wurde.</p>
     
-    <p tal:omit-tag="textual“>Vielen Dank für deine Teilnahme! Wir freuen uns, dich in unserer Gemeinschaft begrüßen zu dürfen.</p>
+    <p tal:omit-tag="textual">Vielen Dank für deine Teilnahme! Wir freuen uns, dich in unserer Gemeinschaft begrüßen zu dürfen.</p>
     
-    <p tal:omit-tag="textual“>Nachdem dein Antrag genehmigt wurde, kannst du dich mit dem Pseudonym und dem Passwort, das du während des Antragsverfahrens angegeben hast, auf unserer Plattform anmelden. Nach der Anmeldung findest du:</p>
-    <ul tal:omit-tag="textual“>
-        <li tal:omit-tag="textual“>die Links zu allen Softwareanwendungen, auf die du direkt zugreifen kannst. Du musst dich nicht erneut anmelden!</li>
-        <li tal:omit-tag="textual“>ein Link zu dem Formular, in dem du dein eigenes Profil anzeigen und bearbeiten kannst. In diesem Formular kannst du dich den anderen Mitgliedern unserer Gemeinschaft in einem kurzen „Profiltext“ vorstellen und ein kleines Bild anzeigen, das dich repräsentiert (dein „Avatar“);</li>
-        <li tal:omit-tag="textual“>einen Link zum Abmelden.</li>
+    <p tal:omit-tag="textual">Nachdem dein Antrag genehmigt wurde, kannst du dich mit dem Pseudonym und dem Passwort, das du während des Antragsverfahrens angegeben hast, auf unserer Plattform anmelden. Nach der Anmeldung findest du:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">die Links zu allen Softwareanwendungen, auf die du direkt zugreifen kannst. Du musst dich nicht erneut anmelden! Besuche vorrangig unseren <a href="https://workspace.<span tal:replace="domain_name„>Domainname</span>">Arbeitsbereich</a>, wo der Großteil unserer Aktivitäten stattfindet;</li>
+        <li tal:omit-tag="textual">ein Link zu dem Formular, in dem du dein eigenes Profil anzeigen und bearbeiten kannst. In diesem Formular kannst du dich den anderen Mitgliedern unserer Gemeinschaft in einem kurzen „Profiltext" vorstellen;</li>
+        <li tal:omit-tag="textual">einen Link zum Abmelden.</li>
     </ul>
 
-    <p tal:omit-tag="textual“>Hier sind die wichtigsten Elemente deines Profils, die wir erfasst haben:</p>
-    <ul tal:omit-tag="textual“>
-        <li tal:omit-tag="textual“>dein Pseudonym: ##PSEUDONYM. Bitte bewahre dieses Pseudonym SORGFÄLTIG UND SICHER auf: Es ist die einzige Kennung, mit der du dich auf unserer IT-Plattform anmelden kannst;</li>
-        <li tal:omit-tag="textual“>dein Passwort: (das Passwort, das du bei deiner Registrierung angegeben hast);</li>
-        <li tal:omit-tag="textual“>deine E-Mail-Adresse: (die E-Mail-Adresse, an die wir diese E-Mail senden);</li>
-        <li tal:omit-tag="textual“ tal:condition="##IS_COOPERATOR“>Deine Identitätsdaten: (alle von Dir angegebenen Vor- und Nachnamen, Dein Geburtsdatum, wie bei der Registrierung angegeben und überprüft);</li>
-        <li tal:omit-tag="textual“>Deine bevorzugte Sprache für die Kommunikation mit uns: ##LANGUAGE_1;</li>
-        <li tal:omit-tag="textual“>die zweite Sprache, die du akzeptierst, damit wir mit dir kommunizieren können: ##LANGUAGE_2;</li>
-        <li tal:omit-tag="textual“>die Sprache, die du als dritte Wahl akzeptierst, um mit uns zu kommunizieren: ##LANGUAGE_3.</li>
+    <p tal:omit-tag="textual">Hier sind die wichtigsten Elemente deines Profils, die wir erfasst haben:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">dein Pseudonym: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Bitte bewahre dieses Pseudonym sorgfältig und sicher auf: Es ist die Kennung, die du während deiner gesamten Tätigkeit auf unserer IT-Plattform verwenden wirst;</li>
+        <li tal:omit-tag="textual">dein Passwort: (das Passwort, das du bei deiner Registrierung angegeben hast);</li>
+        <li tal:omit-tag="textual">deine E-Mail-Adresse: (die E-Mail-Adresse, an die wir diese E-Mail senden);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">deine Identitätsdaten: (alle von dir angegebenen Vor- und Nachnamen, dein Geburtsdatum, wie bei der Registrierung angegeben und überprüft);</li>
+        <li tal:omit-tag="textual">deine bevorzugte Sprache für die Kommunikation mit uns: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
+        <li tal:omit-tag="textual">die zweite Sprache, die du akzeptierst, damit wir mit dir kommunizieren können: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
+        <li tal:omit-tag="textual">die Sprache, die du als dritte Wahl akzeptierst, um mit uns zu kommunizieren: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>
         </ul>
 
-    <p tal:omit-tag="textual“>Zu deiner Information findest du hier die Details zum Abschluss deines Registrierungsprozesses:</p>
-    <ul tal:omit-tag="textual“>
-        <li tal:omit-tag="textual“>Bewerbungs-ID: <span tal:replace="python:candidature.oid“>Bewerbungs-ID</span></li>
-        <li tal:omit-tag="textual“>Genehmigungsdatum: <span tal:replace="python:candidature.modifications[-1]“>Letzte Änderung</span></li>
-        <li tal:omit-tag="textual“>Status: Genehmigt</li>
+    <p tal:omit-tag="textual">Zu deiner Information findest du hier die Details zum Abschluss deines Registrierungsprozesses:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">Bewerbungs-ID: <span tal:replace="python:candidature.oid">Bewerbungs-ID</span></li>
+        <li tal:omit-tag="textual">Genehmigungsdatum: <span tal:replace="python:candidature.modifications[-1]">Letzte Änderung</span></li>
+        <li tal:omit-tag="textual">Status: Genehmigt</li>
     </ul>
 
     
-    <p tal:omit-tag="textual“>Wir freuen uns auf die Zusammenarbeit mit dir!</p>
+    <p tal:omit-tag="textual">Wir freuen uns auf die Zusammenarbeit mit dir!</p>
 
     <p tal:omit-tag="textual">Mit freundlichen Grüßen,</p>
     <p tal:omit-tag="textual">Das Team von <span tal:replace="domain_name">Domain Name</span></p>

--- a/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/de/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -27,7 +27,7 @@
         <li tal:omit-tag="textual">dein Pseudonym: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Bitte bewahre dieses Pseudonym sorgfältig und sicher auf: Es ist die Kennung, die du während deiner gesamten Tätigkeit auf unserer IT-Plattform verwenden wirst;</li>
         <li tal:omit-tag="textual">dein Passwort: (das Passwort, das du bei deiner Registrierung angegeben hast);</li>
         <li tal:omit-tag="textual">deine E-Mail-Adresse: (die E-Mail-Adresse, an die wir diese E-Mail senden);</li>
-        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">deine Identitätsdaten: (alle von dir angegebenen Vor- und Nachnamen, dein Geburtsdatum, wie bei der Registrierung angegeben und überprüft);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR">deine Identitätsdaten: (alle von dir angegebenen Vor- und Nachnamen, dein Geburtsdatum, wie bei der Registrierung angegeben und überprüft);</li>
         <li tal:omit-tag="textual">deine bevorzugte Sprache für die Kommunikation mit uns: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
         <li tal:omit-tag="textual">die zweite Sprache, die du akzeptierst, damit wir mit dir kommunizieren können: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
         <li tal:omit-tag="textual">die Sprache, die du als dritte Wahl akzeptierst, um mit uns zu kommunizieren: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>

--- a/alirpunkto/locale/de/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/de/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    
+tal:omit-tag="textual">
+<head tal:omit-tag="textual">
+    <title tal:omit-tag=‚textual‘>Dein Antrag für den <span tal:replace="domain_name">Domainnamen</span> wurde abgelehnt</title>
+</head>
+<body tal:omit-tag="textual">
+    <h1 tal:omit-tag="textual">Wir müssen dir leider mitteilen, dass dein Antrag abgelehnt wurde</h1>
+    
+    <p tal:omit-tag=‚textual‘>Hallo <span tal:replace="python:candidature.pseudonym">Name des Antragstellers</span>,</p>
+        <p tal:omit-tag="textual">Wir müssen dir leider mitteilen, dass deine Bewerbung bei <span tal:replace=‚domain_name‘>Domainname</span> für die Rolle <span tal:replace=‚python:candidature.type‘>Rolle</span> abgelehnt wurde.
+ Der Grund dafür ist, dass eine Mehrheit der Prüfer der Ansicht war, dass die von dir angegebenen Identitätsdaten (Vorname und Nachname, Geburtsdatum) nicht mit denen deiner amtlichen Ausweisdokumente übereinstimmen oder dass dein aktuelles Selfie nicht ausreichend mit dem Foto auf deinem amtlichen Ausweisdokument übereinstimmt. Wenn du der Meinung bist, dass es sich hierbei um einen Fehler handelt, laden wir dich ein, deine Bewerbung erneut einzureichen, vielleicht mit klareren Kopien deiner amtlichen Ausweisdokumente oder einem besseren Selfie.</p>
+    <p tal:omit-tag="textual">Wir sind uns der Enttäuschung und Frustration bewusst, die diese Ablehnung bei dir auslösen kann, und entschuldigen uns dafür. Andererseits möchten wir dich bitten zu bedenken, dass die Strenge unseres Bewerbungsverfahrens notwendig ist, um sicherzustellen, dass das demokratische Prinzip "eine Person – eine Stimme" in unserer Genossenschaft gewahrt bleibt und dass nur Bürger der Europäischen Union, die älter als 18 Jahre sind, Genossenschafter werden dürfen. </p>
+
+<p tal:omit-tag="textual">Zu deiner Information findest du hier die Details zum Abschluss deiner Anmeldung:</p>
+    <ul tal:omit-tag=‚textual‘>
+        <li tal:omit-tag="textual">Bewerbungs-ID: <span tal:replace="python:candidature.oid">Antrags-ID</span></li>
+        <li tal:omit-tag=‚textual‘>Ablehnungsdatum: <span tal:replace="python:candidature.modifications[-1]">Letzter Statuswechsel</span></li>
+        <li tal:omit-tag="textual">Status: Abgelehnt</li>
+    
+</ul>
+
+    
+    <p tal:omit-tag="textual">Wir bedauern erneut aufrichtig die Enttäuschung, die wir dir möglicherweise bereitet haben, und senden dir unsere </p>
+
+    
+    <p tal:omit-tag="textual">Herzlichen Grüße.</p>
+    
+<p tal:omit-tag="textual">Das Team von <span tal:replace="domain_name">Domain Name</span>.</p>
+    <p tal:omit-tag=‚textual‘ tal:content="organization_details">Angaben zur Organisation</p>
+</body>
+</html>

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -24,13 +24,13 @@
 
     <p tal:omit-tag="textual">Here are main elements of your profile that we recorded:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">your pseudonym: ##PSEUDONYM. Please keep a CAREFUL AND SECURE RECORD of this pseudonym: it is the only identifier with which you can log in to our IT platform;</li>
+        <li tal:omit-tag="textual">your pseudonym: <span tal:replace="user" tal:condition="exists:user" tal:omit-tag="textual">Applicant's Name</span>. Please keep a CAREFUL AND SECURE RECORD of this pseudonym: it is the only identifier with which you can log in to our IT platform;</li>
         <li tal:omit-tag="textual">your password: (the password that you provided upon your registration);</li>
         <li tal:omit-tag="textual">your e-mail address: (the e-mail address to which we send the present e-mail);</li>
-        <li tal:omit-tag="textual" tal:condition="##IS_COOPERATOR">your identity data: (all your given and family names, your date of birth, as provided and verified during your registration process);</li>
-        <li tal:omit-tag="textual">your preferred language for us to interact with you: ##LANGUAGE_1;</li>
-        <li tal:omit-tag="textual">the second language that you accept that we use to interact with you: ##LANGUAGE_2;</li>
-        <li tal:omit-tag="textual">the language that you accept that we use, as a third choice, to interact with you: ##LANGUAGE_3.</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">your identity data: (all your given and family names, your date of birth, as provided and verified during your registration process);</li>
+        <li tal:omit-tag="textual">your preferred language for us to interact with you: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
+        <li tal:omit-tag="textual">the second language that you accept that we use to interact with you: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
+        <li tal:omit-tag="textual">the language that you accept that we use, as a third choice, to interact with you: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>
         </ul>
 
     <p tal:omit-tag="textual">For your records, here are the details of the finalisation of your registration process:</p>

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -9,7 +9,7 @@
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">Congratulations on the approval of your Application!</h1>
     
-    <p tal:omit-tag="textual">Hello <span tal:replace="user" tal:condition="exists:user" tal:omit-tag="textual">Applicant's Name</span>,</p>
+    <p tal:omit-tag="textual">Hello <span tal:replace="python:candidature.pseudonym">Applicant's Name</span>,</p>
     
     <p tal:omit-tag="textual">We are pleased to inform you that your application to the <span tal:replace="domain_name">Domain name</span> for the role of <span tal:replace="python:candidature.type">Role</span> has been approved.</p>
 
@@ -24,7 +24,7 @@
 
     <p tal:omit-tag="textual">Here are main elements of your profile that we recorded:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">your pseudonym: <span tal:replace="user" tal:condition="exists:user" tal:omit-tag="textual">Applicant's Name</span>. Please keep a CAREFUL AND SECURE RECORD of this pseudonym: it is the only identifier with which you can log in to our IT platform;</li>
+        <li tal:omit-tag="textual">your pseudonym: <span tal:replace="python:candidature.pseudonym">Applicant's Name</span>. Please keep a CAREFUL AND SECURE RECORD of this pseudonym: it is the only identifier with which you can log in to our IT platform;</li>
         <li tal:omit-tag="textual">your password: (the password that you provided upon your registration);</li>
         <li tal:omit-tag="textual">your e-mail address: (the e-mail address to which we send the present e-mail);</li>
         <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">your identity data: (all your given and family names, your date of birth, as provided and verified during your registration process);</li>

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -27,7 +27,7 @@
         <li tal:omit-tag="textual">your pseudonym: <span tal:replace="python:candidature.pseudonym">Applicant's pseudonym</span>. Please keep a careful and secure record of this pseudonym: it is the identifier that you will use throughout your activity on our IT platform;</li>
         <li tal:omit-tag="textual">your password: (the password that you provided upon your registration);</li>
         <li tal:omit-tag="textual">your e-mail address: (the e-mail address to which we send the present e-mail);</li>
-        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">your identity data: (all your given and family names, your date of birth, as provided and verified during your registration process);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR">your identity data: (all your given and family names, your date of birth, as provided and verified during your registration process);</li>
         <li tal:omit-tag="textual">your preferred language for us to interact with you: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
         <li tal:omit-tag="textual">the second language that you accept that we use to interact with you: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
         <li tal:omit-tag="textual">the language that you accept that we use, as a third choice, to interact with you: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,10 +17,11 @@
     
     <p tal:omit-tag="textual">Now that your application has been approved, you can log in to our platform using the pseudonym and password you provided during the application process. After having logged in, you will find:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">the links to all the software applications that you have directly access to. You don't need to log in again! Visit in priority our <a tal:attributes="href string:https://workspace.${domain_name}">workspace</a>, where the bulk of our activity takes place;</li>
+        <li tal:omit-tag="textual">the links to all the software applications that you have directly access to. You don't need to log in again! Visit in priority our <a href="https://workspace.cosmopolitical.coop/login">workspace</a>, where the bulk of our activity takes place;</li>
         <li tal:omit-tag="textual">a link to the form where you can view and edit your own profile. On this form, we encourage you to present yourself to the other members of our Community in a short "profile text";</li>
         <li tal:omit-tag="textual">a link to log out.</li>
     </ul>
+ <p tal:omit-tag= "textual" tal:condition= "python:candidature.type==MemberTypes.COOPERATOR"> <strong>Don’t forget!</strong> To enjoy all your rights as a Co-operator, and in particular to be entitled to vote, you must: (1) <a href="https://www.cosmopolitical.coop/Share">purchase at least one share in the Cooperative</a> and (2) <a href="https://www.cosmopolitical.coop/YearContrib">pay your annual contribution</a>. Do this as soon as possible!</p>
 
     <p tal:omit-tag="textual">Here are main elements of your profile that we recorded:</p>
     <ul tal:omit-tag="textual">

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -4,27 +4,27 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:omit-tag="textual">
 <head tal:omit-tag="textual">
-    <title tal:omit-tag="textual">Your Application to the <span tal:replace="domain_name">Domain Name</span> has been approved</title>
+    <title tal:omit-tag="textual">Your Application to the <span tal:replace="domain_name">Domain Name</span> platform has been approved</title>
 </head>
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">Congratulations on the approval of your Application!</h1>
     
     <p tal:omit-tag="textual">Hello <span tal:replace="python:candidature.pseudonym">Applicant's Name</span>,</p>
     
-    <p tal:omit-tag="textual">We are pleased to inform you that your application to the <span tal:replace="domain_name">Domain name</span> for the role of <span tal:replace="python:candidature.type">Role</span> has been approved.</p>
+    <p tal:omit-tag="textual">We are pleased to inform you that your application to the <span tal:replace="domain_name">Domain name</span> platform for the role of <span tal:replace="python:candidature.type">Role</span> has been approved.</p>
 
     <p tal:omit-tag="textual">Thank you for joining us! We are happy to welcome you in our Community./p>
     
     <p tal:omit-tag="textual">Now that your application has been approved, you can log in to our platform using the pseudonym and password you provided during the application process. After having logged in, you will find:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">the links to all the software applications that you have directly access to. You don't need to log in again!</li>
-        <li tal:omit-tag="textual">a link to the form where you can view and edit your own profile. On this form, we encourage you to present yourself to the other members of our Community in a short "profile text" and to display a small picture that represents you (your "avatar");</li>
+        <li tal:omit-tag="textual">the links to all the software applications that you have directly access to. You don't need to log in again! Visit in priority our <a href="https://workspace.<span tal:replace="domain_name">Domain name</span>">workspace</a>, where the bulk of our activity takes place;</li>
+        <li tal:omit-tag="textual">a link to the form where you can view and edit your own profile. On this form, we encourage you to present yourself to the other members of our Community in a short "profile text";</li>
         <li tal:omit-tag="textual">a link to log out.</li>
     </ul>
 
     <p tal:omit-tag="textual">Here are main elements of your profile that we recorded:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">your pseudonym: <span tal:replace="python:candidature.pseudonym">Applicant's Name</span>. Please keep a CAREFUL AND SECURE RECORD of this pseudonym: it is the only identifier with which you can log in to our IT platform;</li>
+        <li tal:omit-tag="textual">your pseudonym: <span tal:replace="python:candidature.pseudonym">Applicant's pseudonym</span>. Please keep a careful and secure record of this pseudonym: it is the identifier that you will use throughout your activity on our IT platform;</li>
         <li tal:omit-tag="textual">your password: (the password that you provided upon your registration);</li>
         <li tal:omit-tag="textual">your e-mail address: (the e-mail address to which we send the present e-mail);</li>
         <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">your identity data: (all your given and family names, your date of birth, as provided and verified during your registration process);</li>

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -13,7 +13,7 @@
     
     <p tal:omit-tag="textual">We are pleased to inform you that your application to the <span tal:replace="domain_name">Domain name</span> platform for the role of <span tal:replace="python:candidature.type">Role</span> has been approved.</p>
 
-    <p tal:omit-tag="textual">Thank you for joining us! We are happy to welcome you in our Community./p>
+    <p tal:omit-tag="textual">Thank you for joining us! We are happy to welcome you in our Community.</p>
     
     <p tal:omit-tag="textual">Now that your application has been approved, you can log in to our platform using the pseudonym and password you provided during the application process. After having logged in, you will find:</p>
     <ul tal:omit-tag="textual">

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,7 +17,7 @@
     
     <p tal:omit-tag="textual">Now that your application has been approved, you can log in to our platform using the pseudonym and password you provided during the application process. After having logged in, you will find:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">the links to all the software applications that you have directly access to. You don't need to log in again! Visit in priority our <a href="https://workspace.<span tal:replace="domain_name">Domain name</span>">workspace</a>, where the bulk of our activity takes place;</li>
+        <li tal:omit-tag="textual">the links to all the software applications that you have directly access to. You don't need to log in again! Visit in priority our <a tal:attributes="href string:https://workspace.${domain_name}">workspace</a>, where the bulk of our activity takes place;</li>
         <li tal:omit-tag="textual">a link to the form where you can view and edit your own profile. On this form, we encourage you to present yourself to the other members of our Community in a short "profile text";</li>
         <li tal:omit-tag="textual">a link to log out.</li>
     </ul>

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    tal:omit-tag="textual">
+<head tal:omit-tag="textual">
+    <title tal:omit-tag="textual">Your Application to the <span tal:replace="domain_name">Domain Name</span> has been rejected</title>
+</head>
+<body tal:omit-tag="textual">
+    <h1 tal:omit-tag="textual">We regret to inform  you of the rejection of your Application</h1>
+    
+    <p tal:omit-tag="textual">Hello <span tal:replace="user" tal:condition="exists:user" tal:omit-tag="textual">Applicant's Name</span>,</p>
+    
+    <p tal:omit-tag="textual">We regret to inform you that your application to the <span tal:replace="domain_name">Domain name</span> for the role of <span tal:replace="python:candidature.type">Role</span> has been rejected. The reason for this is that a majority of Verifiers considered that the information that you provided on your identity (given and family names, date of birth) did not match those of your official identity documents, or that your recent selfie did not sufficiently match the photograph of your official identity document. If you believe that this is an error, we invite you to submit your application again, maybe with clearer copies of your official identity documents or a better selfie image.</p>
+    <p tal:omit-tag="textual">We are aware of the disappointment and frustration that this rejection may cause you, and apologise for this. On the other hand, we invite you to consider that the rigour of our application process is needed to ensure that the democratic principle "one person - one vote" is respected in our Cooperative, and that only citizens of the European Union above 18 years of age are allowed to be Cooperators.</p>
+
+<p tal:omit-tag="textual">For your records, here are the details of the finalisation of your registration process:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">Candidature ID: <span tal:replace="python:candidature.oid">Application ID</span></li>
+        <li tal:omit-tag="textual">Rejection Date: <span tal:replace="python:candidature.modifications[-1]">Last transition</span></li>
+        <li tal:omit-tag="textual">Status: Rejected</li>
+    </ul>
+
+    
+    <p tal:omit-tag="textual">We are again sincerely sorry for the disappointment that we may have caused to you, and send you our </p>
+
+    
+    <p tal:omit-tag="textual">Best regards,</p>
+    <p tal:omit-tag="textual">The team of <span tal:replace="domain_name">Domain Name</span>.</p>
+    <p tal:omit-tag="textual" tal:content="organization_details">Organization details</p>
+</body>
+</html>

--- a/alirpunkto/locale/en/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/en/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -9,7 +9,7 @@
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">We regret to inform  you of the rejection of your Application</h1>
     
-    <p tal:omit-tag="textual">Hello <span tal:replace="user" tal:condition="exists:user" tal:omit-tag="textual">Applicant's Name</span>,</p>
+    <p tal:omit-tag="textual">Hello <span tal:replace="python:candidature.pseudonym">Applicant's Name</span>,</p>
     
     <p tal:omit-tag="textual">We regret to inform you that your application to the <span tal:replace="domain_name">Domain name</span> for the role of <span tal:replace="python:candidature.type">Role</span> has been rejected. The reason for this is that a majority of Verifiers considered that the information that you provided on your identity (given and family names, date of birth) did not match those of your official identity documents, or that your recent selfie did not sufficiently match the photograph of your official identity document. If you believe that this is an error, we invite you to submit your application again, maybe with clearer copies of your official identity documents or a better selfie image.</p>
     <p tal:omit-tag="textual">We are aware of the disappointment and frustration that this rejection may cause you, and apologise for this. On the other hand, we invite you to consider that the rigour of our application process is needed to ensure that the democratic principle "one person - one vote" is respected in our Cooperative, and that only citizens of the European Union above 18 years of age are allowed to be Cooperators.</p>

--- a/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -9,28 +9,28 @@
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">¡Felicidades por la aprobación de tu Solicitud!</h1>
     
-    <p tal:omit-tag="textual">Hola <span tal:replace="user" tal:condition="exists:user">Nombre del Solicitante</span>,</p>
+    <p tal:omit-tag="textual">Hola <span tal:replace="python:candidature.pseudonym">pseudonym</span>,</p>
     
-    <p tal:omit-tag="textual">Tenemos el placer de informarte de que tu solicitud a la <span tal:replace="domain_name">Site name</span> para el rol de <span tal:replace="python:candidature.type">Role</span> ha sido aprobada.</p>
+    <p tal:omit-tag="textual">Tenemos el placer de informarte de que tu solicitud a la plataforma de <span tal:replace="domain_name">Site name</span> para el rol de <span tal:replace="python:candidature.type">Role</span> ha sido aprobada.</p>
     
     <p tal:omit-tag="textual">¡Gracias por unirte a nosotros! Nos complace darte la bienvenida a nuestra Comunidad.</p>
     
     <p tal:omit-tag="textual">Ahora que tu solicitud ha sido aprobada, puedes iniciar sesión en nuestra plataforma utilizando el seudónimo y la contraseña que proporcionaste durante el proceso de solicitud. Después de haber iniciado sesión, encontrarás:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte!</li>
-        <li tal:omit-tag="textual">un enlace al formulario donde puedes ver y editar tu propio perfil. En este formulario, te animamos a presentarte a los demás miembros de nuestra Comunidad con un breve «texto de perfil» y a mostrar una pequeña foto que te represente (tu «avatar»);</li>
+        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte! Visita antes de nada nuestro <a href="https://workspace.<span tal:replace="domain_name«>nombre de dominio</span>»>espacio de trabajo</a>, donde se desarrolla la mayor parte de nuestra actividad;</li>
+        <li tal:omit-tag="textual">un enlace al formulario donde puedes ver y editar tu propio perfil. En este formulario, te animamos a presentarte a los demás miembros de nuestra Comunidad con un breve «texto de perfil»;</li>
         <li tal:omit-tag="textual">un enlace para cerrar la sesión.</li>
     </ul>
 
     <p tal:omit-tag="textual">Aquí tienes los principales elementos de tu perfil que registramos:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">Tu seudónimo: ##PSEUDONYM. Por favor, guarda un REGISTRO CUIDADOSO Y SEGURO de este seudónimo: es el único identificador con el que puedes iniciar sesión en nuestra plataforma informática;</li>
+        <li tal:omit-tag="textual">Tu seudónimo: <span tal:replace="python:candidature.pseudonym">pseudonym</span>.Por favor, guarda bien este seudónimo: es el identificador que usarás durante toda tu actividad en nuestra plataforma informática;</li>
         <li tal:omit-tag="textual">tu contraseña: (la contraseña que proporcionaste al registrarte);</li>
         <li tal:omit-tag="textual">tu dirección de correo electrónico: (la dirección de correo electrónico a la que enviamos el presente correo electrónico);</li>
-        <li tal:omit-tag="textual" tal:condition="##IS_COOPERATOR">Tus datos de identidad: (todos tus nombres y apellidos, tu fecha de nacimiento, tal y como se facilitaron y verificaron durante el proceso de registro);</li>
-        <li tal:omit-tag="textual">tu idioma preferido para que interactuemos contigo: ##LANGUAGE_1;</li>
-        <li tal:omit-tag="textual">la segunda lengua que aceptas que utilicemos para interactuar contigo: ##LANGUAGE_2;</li>
-        <li tal:omit-tag="textual">la lengua que aceptas que utilicemos, como tercera opción, para interactuar contigo: ##LANGUAGE_3.</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">Tus datos de identidad: (todos tus nombres y apellidos, tu fecha de nacimiento, tal y como se facilitaron y verificaron durante el proceso de registro);</li>
+        <li tal:omit-tag="textual">tu idioma preferido para que interactuemos contigo: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
+        <li tal:omit-tag="textual">la segunda lengua que aceptas que utilicemos para interactuar contigo: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
+        <li tal:omit-tag="textual">la lengua que aceptas que utilicemos, como tercera opción, para interactuar contigo: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>
         </ul>
 
     <p tal:omit-tag="textual">Para tu información, aquí tienes los detalles de la finalización de tu proceso de registro:</p>

--- a/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -27,7 +27,7 @@
         <li tal:omit-tag="textual">Tu seudónimo: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Por favor, guarda bien este seudónimo: es el identificador que usarás durante toda tu actividad en nuestra plataforma informática;</li>
         <li tal:omit-tag="textual">tu contraseña: (la contraseña que proporcionaste al registrarte);</li>
         <li tal:omit-tag="textual">tu dirección de correo electrónico: (la dirección de correo electrónico a la que enviamos el presente correo electrónico);</li>
-        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">Tus datos de identidad: (todos tus nombres y apellidos, tu fecha de nacimiento, tal y como se facilitaron y verificaron durante el proceso de registro);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR">Tus datos de identidad: (todos tus nombres y apellidos, tu fecha de nacimiento, tal y como se facilitaron y verificaron durante el proceso de registro);</li>
         <li tal:omit-tag="textual">tu idioma preferido para que interactuemos contigo: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
         <li tal:omit-tag="textual">la segunda lengua que aceptas que utilicemos para interactuar contigo: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
         <li tal:omit-tag="textual">la lengua que aceptas que utilicemos, como tercera opción, para interactuar contigo: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>

--- a/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,10 +17,12 @@
     
     <p tal:omit-tag="textual">Ahora que tu solicitud ha sido aprobada, puedes iniciar sesión en nuestra plataforma utilizando el seudónimo y la contraseña que proporcionaste durante el proceso de solicitud. Después de haber iniciado sesión, encontrarás:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte! Visita antes de nada nuestro <a tal:attributes="href string:https://workspace.${domain_name}">espacio de trabajo</a>, donde se desarrolla la mayor parte de nuestra actividad;</li>
+        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte! Visita antes de nada nuestro <a href="https://workspace.cosmopolitical.coop/login">espacio de trabajo</a>, donde se desarrolla la mayor parte de nuestra actividad;</li>
         <li tal:omit-tag="textual">un enlace al formulario donde puedes ver y editar tu propio perfil. En este formulario, te animamos a presentarte a los demás miembros de nuestra Comunidad con un breve «texto de perfil»;</li>
         <li tal:omit-tag="textual">un enlace para cerrar la sesión.</li>
     </ul>
+
+ <p tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR"> <strong>¡No te olvides!</strong> Para disfrutar de todos tus derechos como cooperador, y sobre todo para poder votar, tienes que: (1) <a href="https://www.cosmopolitical.coop/Share">comprar al menos una participación en la Cooperativa</a> y (2) <a href="https://www.cosmopolitical.coop/YearContrib">pagar tu cuota anual</a>. ¡Hazlo lo antes posible!</p>
 
     <p tal:omit-tag="textual">Aquí tienes los principales elementos de tu perfil que registramos:</p>
     <ul tal:omit-tag="textual">

--- a/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -4,7 +4,7 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:omit-tag="textual">
 <head tal:omit-tag="textual">
-    <title tal:omit-tag="textual">Tu solicitud para la <span tal:replace="domain_name">Nombre del sitio</span> ha sido aprobada</title>
+    <title tal:omit-tag="textual">Tu solicitud a la plataforma de <span tal:replace="domain_name">Nombre del sitio</span> ha sido aprobada</title>
 </head>
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">¡Felicidades por la aprobación de tu Solicitud!</h1>

--- a/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,7 +17,7 @@
     
     <p tal:omit-tag="textual">Ahora que tu solicitud ha sido aprobada, puedes iniciar sesión en nuestra plataforma utilizando el seudónimo y la contraseña que proporcionaste durante el proceso de solicitud. Después de haber iniciado sesión, encontrarás:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte! Visita antes de nada nuestro <a href="https://workspace.<span tal:replace="domain_name">nombre de dominio</span>">espacio de trabajo</a>, donde se desarrolla la mayor parte de nuestra actividad;</li>
+        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte! Visita antes de nada nuestro <a tal:attributes="href string:https://workspace.${domain_name}">espacio de trabajo</a>, donde se desarrolla la mayor parte de nuestra actividad;</li>
         <li tal:omit-tag="textual">un enlace al formulario donde puedes ver y editar tu propio perfil. En este formulario, te animamos a presentarte a los demás miembros de nuestra Comunidad con un breve «texto de perfil»;</li>
         <li tal:omit-tag="textual">un enlace para cerrar la sesión.</li>
     </ul>

--- a/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/es/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,14 +17,14 @@
     
     <p tal:omit-tag="textual">Ahora que tu solicitud ha sido aprobada, puedes iniciar sesión en nuestra plataforma utilizando el seudónimo y la contraseña que proporcionaste durante el proceso de solicitud. Después de haber iniciado sesión, encontrarás:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte! Visita antes de nada nuestro <a href="https://workspace.<span tal:replace="domain_name«>nombre de dominio</span>»>espacio de trabajo</a>, donde se desarrolla la mayor parte de nuestra actividad;</li>
+        <li tal:omit-tag="textual">los enlaces a todas las aplicaciones informáticas a las que tienes acceso directo. ¡No necesitas volver a conectarte! Visita antes de nada nuestro <a href="https://workspace.<span tal:replace="domain_name">nombre de dominio</span>">espacio de trabajo</a>, donde se desarrolla la mayor parte de nuestra actividad;</li>
         <li tal:omit-tag="textual">un enlace al formulario donde puedes ver y editar tu propio perfil. En este formulario, te animamos a presentarte a los demás miembros de nuestra Comunidad con un breve «texto de perfil»;</li>
         <li tal:omit-tag="textual">un enlace para cerrar la sesión.</li>
     </ul>
 
     <p tal:omit-tag="textual">Aquí tienes los principales elementos de tu perfil que registramos:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">Tu seudónimo: <span tal:replace="python:candidature.pseudonym">pseudonym</span>.Por favor, guarda bien este seudónimo: es el identificador que usarás durante toda tu actividad en nuestra plataforma informática;</li>
+        <li tal:omit-tag="textual">Tu seudónimo: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Por favor, guarda bien este seudónimo: es el identificador que usarás durante toda tu actividad en nuestra plataforma informática;</li>
         <li tal:omit-tag="textual">tu contraseña: (la contraseña que proporcionaste al registrarte);</li>
         <li tal:omit-tag="textual">tu dirección de correo electrónico: (la dirección de correo electrónico a la que enviamos el presente correo electrónico);</li>
         <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">Tus datos de identidad: (todos tus nombres y apellidos, tu fecha de nacimiento, tal y como se facilitaron y verificaron durante el proceso de registro);</li>

--- a/alirpunkto/locale/es/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/es/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    
+tal:omit-tag="textual">
+<head tal:omit-tag="textual">
+    <title tal:omit-tag=“textual”>Tu solicitud para el <span tal:replace="domain_name">nombre de dominio</span> ha sido rechazada</title>
+</head>
+<body tal:omit-tag="textual">
+    <h1 tal:omit-tag="textual">Lamentamos informarte de que tu solicitud ha sido rechazada</h1>
+    
+    <p tal:omit-tag=“textual”>Hola, <span tal:replace="python:candidature.pseudonym">Nombre del solicitante</span>,</p>
+        <p tal:omit-tag="textual">Lamentamos informarte de que tu solicitud para el <span tal:replace=“domain_name”>nombre de dominio</span> para el papel de <span tal:replace=“python:candidature.type”>papel</span> ha sido rechazada.
+ El motivo es que la mayoría de los verificadores consideraron que la información que proporcionaste sobre tu identidad (nombre y apellidos, fecha de nacimiento) no coincidía con la de tus documentos de identidad oficiales, o que tu selfie reciente no se correspondía lo suficiente con la fotografía de tu documento de identidad oficial. Si crees que se trata de un error, te invitamos a volver a enviar tu solicitud, quizá con copias más nítidas de tus documentos de identidad oficiales o una selfie de mejor calidad.</p>
+    <p tal:omit-tag="textual">Somos conscientes de la decepción y la frustración que este rechazo puede causarte, y te pedimos disculpas por ello. Por otro lado, te invitamos a tener en cuenta que el rigor de nuestro proceso de solicitud es necesario para garantizar que se respete el principio democrático de "una persona, un voto" en nuestra Cooperativa, y que solo los ciudadanos de la Unión Europea mayores de 18 años puedan ser cooperadores. </p>
+
+<p tal:omit-tag="textual">Para que lo tengas en cuenta, aquí tienes los detalles de la finalización de tu proceso de registro:</p>
+    <ul tal:omit-tag=“textual”>
+        <li tal:omit-tag="textual">ID de candidatura: <span tal:replace="python:candidature.oid">ID de la solicitud</span></li>
+        <li tal:omit-tag=“textual”>Fecha de rechazo: <span tal:replace="python:candidature.modifications[-1]">Última transición</span></li>
+        <li tal:omit-tag="textual">Estado: Rechazado</li>
+    
+</ul>
+
+    
+    <p tal:omit-tag="textual">Una vez más, lamentamos de todo corazón la decepción que te hayamos podido causar y te enviamos  </p>
+
+    
+    <p tal:omit-tag="textual">Un saludo cordial.</p>
+    
+<p tal:omit-tag="textual">El equipo de <span tal:replace="domain_name">Nombre de dominio</span>.</p>
+    <p tal:omit-tag=“textual” tal:content="organization_details">Datos de la organización</p>
+</body>
+</html>

--- a/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -27,7 +27,7 @@
         <li tal:omit-tag="textual">ton pseudonyme&nbsp;: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Conserve soigneusement et en toute sécurité ce pseudonyme&nbsp;: c'est l'identifiant que tu utiliseras tout au long de ton activité sur notre plateforme informatique&nbsp;;</li>.
         <li tal:omit-tag="textual">ton mot de passe&nbsp;: (le mot de passe que tu as fourni lors de ton inscription)&nbsp;;</li>.
         <li:omit-tag="textual">ton adresse électronique&nbsp;: (l'adresse électronique à laquelle nous envoyons le présent courriel)&nbsp;;</li>
-        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">tes données d'identité&nbsp;: (tous tes noms et prénoms, ta date de naissance, tels qu'ils ont été fournis et vérifiés au cours de ton processus d'inscription)&nbsp;;</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR">tes données d'identité&nbsp;: (tous tes noms et prénoms, ta date de naissance, tels qu'ils ont été fournis et vérifiés au cours de ton processus d'inscription)&nbsp;;</li>
         <li tal:omit-tag= "textual">la langue que tu préfères pour que nous interagissions avec toi&nbsp;: <span tal:replace="python:candidature.lang1">Language_1</span>&nbsp;;</li>
         <li:omit-tag="textual">la deuxième langue que tu acceptes que nous utilisions pour interagir avec toi&nbsp;: <span tal:replace="python:candidature.lang2">Language_2</span>&nbsp;;</li>
         <li tal:omit-tag="textual">la langue que tu acceptes que nous utilisions, en troisième choix, pour interagir avec toi&nbsp;<span tal:replace="python:candidature.lang3">Language_3</span>.</li> 

--- a/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,7 +17,7 @@
     
     <p tal:omit-tag="textual">Maintenant que ta candidature a été approuvée, tu peux te connecter à notre plateforme en utilisant le pseudonyme et le mot de passe que tu as fournis pendant le processus de candidature. Après t'être connecté.e, tu trouveras :</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">les liens vers toutes les applications logicielles auxquelles tu as directement accès. Tu n'as pas besoin de te reconnecter&nbsp;! Rends-toi en priorité sur notre <a href="https://workspace.<span tal:replace="domain_name">nom de domaine</span>">espace de travail</a>, où se déroule l'essentiel de notre activité&nbsp;;</li>
+        <li tal:omit-tag="textual">les liens vers toutes les applications logicielles auxquelles tu as directement accès. Tu n'as pas besoin de te reconnecter&nbsp;! Rends-toi en priorité sur notre <a tal:attributes="href string:https://workspace.${domain_name}">espace de travail</a>, où se déroule l'essentiel de notre activité&nbsp;;</li>
         <li:omit-tag="textual">un lien vers le formulaire où tu peux consulter et modifier ton propre profil. Sur ce formulaire, nous t'encourageons à te présenter aux autres membres de notre Communauté dans un court "texte de profil";</li>.
         <li tal:omit-tag="textual">un lien permettant de te déconnecter.</li>
     </ul>

--- a/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,11 +17,11 @@
     
     <p tal:omit-tag="textual">Maintenant que ta candidature a été approuvée, tu peux te connecter à notre plateforme en utilisant le pseudonyme et le mot de passe que tu as fournis pendant le processus de candidature. Après t'être connecté.e, tu trouveras :</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">les liens vers toutes les applications logicielles auxquelles tu as directement accès. Tu n'as pas besoin de te reconnecter&nbsp;! Rends-toi en priorité sur notre <a tal:attributes="href string:https://workspace.${domain_name}">espace de travail</a>, où se déroule l'essentiel de notre activité&nbsp;;</li>
+        <li tal:omit-tag="textual">les liens vers toutes les applications logicielles auxquelles tu as directement accès. Tu n'as pas besoin de te reconnecter&nbsp;! Rends-toi en priorité sur notre <a href="https://workspace.cosmopolitical.coop/login">espace de travail</a>, où se déroule l'essentiel de notre activité&nbsp;;</li>
         <li:omit-tag="textual">un lien vers le formulaire où tu peux consulter et modifier ton propre profil. Sur ce formulaire, nous t'encourageons à te présenter aux autres membres de notre Communauté dans un court "texte de profil";</li>.
         <li tal:omit-tag="textual">un lien permettant de te déconnecter.</li>
     </ul>
-
+    <p tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR"> <strong>N'oublie pas&nbsp;!</strong> Pour bénéficier de tous tes droits en tant que Coopérateur, et en particulier pour avoir le droit de vote, tu dois&nbsp;: (1)&nbsp;<a href="https://www.cosmopolitical.coop/Share">acheter au moins une part sociale de la Coopérative</a> et (2)&nbsp;<a href="https://www.cosmopolitical.coop/YearContrib">payer ta contribution annuelle</a>. Fais-le au plus tôt&nbsp;!</p>
     <p tal:omit-tag="textual">Voici les principaux éléments de ton profil que nous avons enregistrés&nbsp;:</p>
     <ul tal:omit-tag="textual">
         <li tal:omit-tag="textual">ton pseudonyme&nbsp;: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Conserve soigneusement et en toute sécurité ce pseudonyme&nbsp;: c'est l'identifiant que tu utiliseras tout au long de ton activité sur notre plateforme informatique&nbsp;;</li>.

--- a/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -4,43 +4,43 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:omit-tag="textual">
 <head tal:omit-tag="textual">
-    <title tal:omit-tag="textual">Ta candidature auprès de la <span tal:replace="domain_name">Nom du site</span> a été approuvée</title>
+    <title tal:omit-tag="textual">Ta candidature auprès de la plate-forme <span tal:replace="domain_name">Nom du site</span> a été approuvée</title>
 </head>
 <body tal:omit-tag="textual">
-    <h1 tal:omit-tag="textual">Félicitations pour la validation de ta candidature!</h1>
+    <h1 tal:omit-tag="textual">Félicitations pour la validation de ta candidature&nbsp;!</h1>
     
-    <p tal:omit-tag="textual">Bonjour <span tal:replace="user" tal:condition="exists:user">Nom du demandeur</span>,</p>
+    <p tal:omit-tag="textual">Bonjour <span tal:replace="python:candidature.pseudonym">pseudonym</span>,</p>
     
-    <p tal:omit-tag="textual">Nous avons le plaisir de t'informer que ta candidature au <span tal:replace="domain_name">nom du site</span> pour le rôle de <span tal:replace="python:candidature.type">Rôle</span> a été approuvée.</p>
+    <p tal:omit-tag="textual">Nous avons le plaisir de t'informer que ta candidature sur la plate-forme de <span tal:replace="domain_name">nom du site</span> pour le rôle de <span tal:replace="python:candidature.type">Rôle</span> a été approuvée.</p>
     
-    <p tal:omit-tag=« textual »>Merci de nous rejoindre ! Nous sommes heureux de t'accueillir au sein de notre Communauté.</p>
+    <p tal:omit-tag="textual">Merci de nous rejoindre&nbsp;! Nous sommes heureux de t'accueillir au sein de notre Communauté.</p>
     
-    <p tal:omit-tag=« textual »>Maintenant que ta candidature a été approuvée, tu peux te connecter à notre plateforme en utilisant le pseudonyme et le mot de passe que tu as fournis pendant le processus de candidature. Après t'être connecté.e, tu trouveras :</p>
-    <ul tal:omit-tag=« textual »>
-        <li tal:omit-tag=« textual »>les liens vers toutes les applications logicielles auxquelles tu as directement accès. Tu n'as pas besoin de te reconnecter !</li>
-        <li:omit-tag=« textual »>un lien vers le formulaire où tu peux consulter et modifier ton propre profil. Sur ce formulaire, nous t'encourageons à te présenter aux autres membres de notre Communauté dans un court « texte de profil » et à afficher une petite image qui te représente (ton « avatar »);</li>.
-        <li tal:omit-tag=« textual »>un lien permettant de te déconnecter.</li>
+    <p tal:omit-tag="textual">Maintenant que ta candidature a été approuvée, tu peux te connecter à notre plateforme en utilisant le pseudonyme et le mot de passe que tu as fournis pendant le processus de candidature. Après t'être connecté.e, tu trouveras :</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">les liens vers toutes les applications logicielles auxquelles tu as directement accès. Tu n'as pas besoin de te reconnecter&nbsp;! Rends-toi en priorité sur notre <a href="https://workspace.<span tal:replace="domain_name">nom de domaine</span>">espace de travail</a>, où se déroule l'essentiel de notre activité&nbsp;;</li>
+        <li:omit-tag="textual">un lien vers le formulaire où tu peux consulter et modifier ton propre profil. Sur ce formulaire, nous t'encourageons à te présenter aux autres membres de notre Communauté dans un court "texte de profil";</li>.
+        <li tal:omit-tag="textual">un lien permettant de te déconnecter.</li>
     </ul>
 
-    <p tal:omit-tag=« textual »>Voici les principaux éléments de ton profil que nous avons enregistrés :</p>
-    <ul tal:omit-tag=« textual »>
-        <li tal:omit-tag= » textual »>ton pseudonyme : ##PSEUDONYM. Conserve soigneusement et en toute sécurité ce pseudonyme : c'est le seul identifiant avec lequel tu peux te connecter à notre plateforme informatique ;</li>.
-        <li tal:omit-tag= » textual »>ton mot de passe : (le mot de passe que tu as fourni lors de ton inscription);</li>.
-        <li:omit-tag= » textual »>ton adresse électronique : (l'adresse électronique à laquelle nous envoyons le présent courriel);</li>
-        <li:omit-tag= » textual “ tal:condition=” ##IS_COOPERATOR »>tes données d'identité : (tous tes noms et prénoms, ta date de naissance, tels qu'ils ont été fournis et vérifiés au cours de ton processus d'inscription);</li>
-        <li tal:omit-tag= « textual »>la langue que tu préfères pour que nous interagissions avec toi : ##LANGUAGE_1;</li>
-        <li:omit-tag=« textual »>la deuxième langue que tu acceptes que nous utilisions pour interagir avec toi : ##LANGUAGE_2;</li>
-        <li tal:omit-tag= » textual »>la langue que tu acceptes que nous utilisions, en troisième choix, pour interagir avec toi : ##LANGUAGE_3;</li> 
-</ul>
-
-    <p tal:omit-tag= » textual »>Pour ton information, voici les détails de la finalisation de ton processus d'inscription :</p> <p>.
-    <ul tal:omit-tag=« textual »>
-        <li tal:omit-tag=« textual »>Identification de la candidature : <span tal:replace=« python:candidature.oid »>Identification de la candidature</span></li>.
-        <li tal:omit-tag=« textual »>Date d'approbation : <span tal:replace=« python:candidature.modifications[-1] »>Dernière transition</span></li>.
-        <li tal:omit-tag= » textual »>Statut : Approuvé</li>
+    <p tal:omit-tag="textual">Voici les principaux éléments de ton profil que nous avons enregistrés&nbsp;:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">ton pseudonyme&nbsp;: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Conserve soigneusement et en toute sécurité ce pseudonyme&nbsp;: c'est l'identifiant que tu utiliseras tout au long de ton activité sur notre plateforme informatique&nbsp;;</li>.
+        <li tal:omit-tag="textual">ton mot de passe&nbsp;: (le mot de passe que tu as fourni lors de ton inscription)&nbsp;;</li>.
+        <li:omit-tag="textual">ton adresse électronique&nbsp;: (l'adresse électronique à laquelle nous envoyons le présent courriel)&nbsp;;</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">tes données d'identité&nbsp;: (tous tes noms et prénoms, ta date de naissance, tels qu'ils ont été fournis et vérifiés au cours de ton processus d'inscription)&nbsp;;</li>
+        <li tal:omit-tag= "textual">la langue que tu préfères pour que nous interagissions avec toi&nbsp;: <span tal:replace="python:candidature.lang1">Language_1</span>&nbsp;;</li>
+        <li:omit-tag="textual">la deuxième langue que tu acceptes que nous utilisions pour interagir avec toi&nbsp;: <span tal:replace="python:candidature.lang2">Language_2</span>&nbsp;;</li>
+        <li tal:omit-tag="textual">la langue que tu acceptes que nous utilisions, en troisième choix, pour interagir avec toi&nbsp;<span tal:replace="python:candidature.lang3">Language_3</span>.</li> 
     </ul>
 
-    <p tal:omit-tag= » textual »>Nous nous réjouissons de la perspective d'avoir le plaisir de travailler avec toi !</p>
+    <p tal:omit-tag="textual">Pour ton information, voici les détails de la finalisation de ton processus d'inscription :</p>.
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">Identification de la candidature&nbsp;: <span tal:replace="python:candidature.oid">Identification de la candidature</span></li>
+        <li tal:omit-tag="textual">Date d'approbation&nbsp;: <span tal:replace="python:candidature.modifications[-1]">Dernière transition</span></li>
+        <li tal:omit-tag="textual">Statut&nbsp;: Approuvé</li>
+    </ul>
+
+    <p tal:omit-tag="textual">Nous nous réjouissons de la perspective d'avoir le plaisir de travailler avec toi&nbsp;!</p>
     
     <p tal:omit-tag="textual">Meilleures salutations,</p>
     <p tal:omit-tag="textual">L'équipe de <span tal:replace="domain_name">Nom du site</span></p>

--- a/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:metal=« http://xml.zope.org/namespaces/metal »
+    xmlns:i18n=« http://xml.zope.org/namespaces/i18n »
+    xmlns:tal=« http://xml.zope.org/namespaces/tal »
+    
+tal:omit-tag=« textual »>
+<head tal:omit-tag=« textual »>
+    <title tal:omit-tag=“textual”>Ta demande concernant le <span tal:replace=« domain_name »>nom de domaine</span> a été rejetée</title>
+</head>
+<body tal:omit-tag=« textual »>
+    <h1 tal:omit-tag=« textual »>Nous avons le regret de t'informer du rejet de ta candidature</h1>
+    
+    <p tal:omit-tag=« textual »>Bonjour <span tal:replace=« python:candidature.pseudonym »>Nom du candidat</span>,</p>
+        <p tal:omit-tag=« textual »>Nous avons le regret de t'informer que ta candidature auprès de <span tal:replace=« domain_name »>Nom de domaine</span> pour le statut de <span tal:replace=« python:candidature.type »>Statut</span> a été rejetée. La raison en est que la majorité des vérificateurs ont estimé que les informations que tu as fournies concernant ton identité (prénom et nom, date de naissance) ne correspondaient pas à celles figurant sur tes pièces d’identité officielles, ou que ton selfie récent ne correspondait pas suffisamment à la photo de ta pièce d’identité officielle. Si tu penses qu’il s’agit d’une erreur, nous t’invitons à soumettre à nouveau ta candidature, éventuellement avec des copies plus lisibles de tes pièces d’identité officielles ou un selfie de meilleure qualité.</p>
+    <p tal:omit-tag=« textual »>Nous sommes conscients de la déception et de la frustration que ce refus peut te causer, et nous t’en présentons nos excuses. D’un autre côté, nous t’invitons à considérer que la rigueur de notre processus de candidature est nécessaire pour garantir le respect du principe démocratique « une personne, une voix » au sein de notre coopérative, et que seuls les citoyens de l’Union européenne âgés de plus de 18 ans sont autorisés à devenir coopérateurs.
+ </p>
+
+<p tal:omit-tag=« textual »>Pour tes archives, voici les détails de la finalisation de ton processus d’inscription :</p>
+    <ul tal:omit-tag=“textual”>
+        <li tal:omit-tag=« textual »>ID de candidature : <span tal:replace=« python:candidature.oid »>ID de candidature</span></li>
+        <li tal:omit-tag=“textual”>Date de rejet : <span tal:replace=« python:candidature.modifications[-1] »>Dernière transition</span></li>
+        <li tal:omit-tag=« textual »>Statut : Rejeté</li>
+    
+</ul>
+
+    
+    <p tal:omit-tag=« textual »>Nous sommes encore une fois sincèrement désolés pour la déception que nous avons pu te causer, et nous t'adressons nos </p>
+
+    
+    <p tal:omit-tag=« textual »>Meilleures salutations,</p>
+    
+<p tal:omit-tag=« textual »>L'équipe de <span tal:replace=« domain_name »>Nom de domaine</span>.</p>
+    <p tal:omit-tag=“textual” tal:content=« organization_details »>Coordonnées de l'organisation</p>
+</body>
+</html>

--- a/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/fr/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,35 +1,35 @@
 <!DOCTYPE html>
-<html xmlns:metal=« http://xml.zope.org/namespaces/metal »
-    xmlns:i18n=« http://xml.zope.org/namespaces/i18n »
-    xmlns:tal=« http://xml.zope.org/namespaces/tal »
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
     
-tal:omit-tag=« textual »>
-<head tal:omit-tag=« textual »>
-    <title tal:omit-tag=“textual”>Ta demande concernant le <span tal:replace=« domain_name »>nom de domaine</span> a été rejetée</title>
+tal:omit-tag="textual">
+<head tal:omit-tag="textual">
+    <title tal:omit-tag=“textual”>Ta demande concernant le <span tal:replace="domain_name">nom de domaine</span> a été rejetée</title>
 </head>
-<body tal:omit-tag=« textual »>
-    <h1 tal:omit-tag=« textual »>Nous avons le regret de t'informer du rejet de ta candidature</h1>
+<body tal:omit-tag="textual">
+    <h1 tal:omit-tag="textual">Nous avons le regret de t'informer du rejet de ta candidature</h1>
     
-    <p tal:omit-tag=« textual »>Bonjour <span tal:replace=« python:candidature.pseudonym »>Nom du candidat</span>,</p>
-        <p tal:omit-tag=« textual »>Nous avons le regret de t'informer que ta candidature auprès de <span tal:replace=« domain_name »>Nom de domaine</span> pour le statut de <span tal:replace=« python:candidature.type »>Statut</span> a été rejetée. La raison en est que la majorité des vérificateurs ont estimé que les informations que tu as fournies concernant ton identité (prénom et nom, date de naissance) ne correspondaient pas à celles figurant sur tes pièces d’identité officielles, ou que ton selfie récent ne correspondait pas suffisamment à la photo de ta pièce d’identité officielle. Si tu penses qu’il s’agit d’une erreur, nous t’invitons à soumettre à nouveau ta candidature, éventuellement avec des copies plus lisibles de tes pièces d’identité officielles ou un selfie de meilleure qualité.</p>
-    <p tal:omit-tag=« textual »>Nous sommes conscients de la déception et de la frustration que ce refus peut te causer, et nous t’en présentons nos excuses. D’un autre côté, nous t’invitons à considérer que la rigueur de notre processus de candidature est nécessaire pour garantir le respect du principe démocratique « une personne, une voix » au sein de notre coopérative, et que seuls les citoyens de l’Union européenne âgés de plus de 18 ans sont autorisés à devenir coopérateurs.
+    <p tal:omit-tag="textual">Bonjour <span tal:replace="python:candidature.pseudonym">Nom du candidat</span>,</p>
+        <p tal:omit-tag="textual">Nous avons le regret de t'informer que ta candidature auprès de <span tal:replace="domain_name">Nom de domaine</span> pour le statut de <span tal:replace="python:candidature.type">Statut</span> a été rejetée. La raison en est que la majorité des vérificateurs ont estimé que les informations que tu as fournies concernant ton identité (prénom et nom, date de naissance) ne correspondaient pas à celles figurant sur tes pièces d’identité officielles, ou que ton selfie récent ne correspondait pas suffisamment à la photo de ta pièce d’identité officielle. Si tu penses qu’il s’agit d’une erreur, nous t’invitons à soumettre à nouveau ta candidature, éventuellement avec des copies plus lisibles de tes pièces d’identité officielles ou un selfie de meilleure qualité.</p>
+    <p tal:omit-tag="textual">Nous sommes conscients de la déception et de la frustration que ce refus peut te causer, et nous t’en présentons nos excuses. D’un autre côté, nous t’invitons à considérer que la rigueur de notre processus de candidature est nécessaire pour garantir le respect du principe démocratique "une personne, une voix" au sein de notre coopérative, et que seuls les citoyens de l’Union européenne âgés de plus de 18 ans sont autorisés à devenir coopérateurs.
  </p>
 
-<p tal:omit-tag=« textual »>Pour tes archives, voici les détails de la finalisation de ton processus d’inscription :</p>
+<p tal:omit-tag="textual">Pour tes archives, voici les détails de la finalisation de ton processus d’inscription :</p>
     <ul tal:omit-tag=“textual”>
-        <li tal:omit-tag=« textual »>ID de candidature : <span tal:replace=« python:candidature.oid »>ID de candidature</span></li>
-        <li tal:omit-tag=“textual”>Date de rejet : <span tal:replace=« python:candidature.modifications[-1] »>Dernière transition</span></li>
-        <li tal:omit-tag=« textual »>Statut : Rejeté</li>
+        <li tal:omit-tag="textual">ID de candidature : <span tal:replace="python:candidature.oid">ID de candidature</span></li>
+        <li tal:omit-tag=“textual”>Date de rejet : <span tal:replace="python:candidature.modifications[-1]">Dernière transition</span></li>
+        <li tal:omit-tag="textual">Statut : Rejeté</li>
     
 </ul>
 
     
-    <p tal:omit-tag=« textual »>Nous sommes encore une fois sincèrement désolés pour la déception que nous avons pu te causer, et nous t'adressons nos </p>
+    <p tal:omit-tag="textual">Nous sommes encore une fois sincèrement désolés pour la déception que nous avons pu te causer, et nous t'adressons nos </p>
 
     
-    <p tal:omit-tag=« textual »>Meilleures salutations,</p>
+    <p tal:omit-tag="textual">Meilleures salutations,</p>
     
-<p tal:omit-tag=« textual »>L'équipe de <span tal:replace=« domain_name »>Nom de domaine</span>.</p>
-    <p tal:omit-tag=“textual” tal:content=« organization_details »>Coordonnées de l'organisation</p>
+<p tal:omit-tag="textual">L'équipe de <span tal:replace="domain_name">Nom de domaine</span>.</p>
+    <p tal:omit-tag=“textual” tal:content="organization_details">Coordonnées de l'organisation</p>
 </body>
 </html>

--- a/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,7 +17,7 @@
     
     <p tal:omit-tag="textual">Ora che la tua candidatura è stata approvata, puoi accedere alla nostra piattaforma utilizzando lo pseudonimo e la password che ci hai fornito durante il processo di candidatura. Dopo aver effettuato il login, troverai:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">i link a tutte le applicazioni software a cui hai accesso diretto. Non è necessario effettuare di nuovo il login! Visita innanzitutto il nostro <a href="https://workspace.<span tal:replace="domain_name">nome di dominio</span>">spazio di lavoro</a>, dove si svolge la maggior parte della nostra attività;</li>
+        <li tal:omit-tag="textual">i link a tutte le applicazioni software a cui hai accesso diretto. Non è necessario effettuare di nuovo il login! Visita innanzitutto il nostro <a tal:attributes="href string:https://workspace.${domain_name}">spazio di lavoro</a>, dove si svolge la maggior parte della nostra attività;</li>
         <li tal:omit-tag="textual">un link al modulo in cui puoi visualizzare e modificare il tuo profilo. In questo modulo, ti invitiamo a presentarti agli altri membri della nostra Comunità con un breve "testo del profilo";</li>
         <li tal:omit-tag="textual">un link per effettuare il logout.</li>
     </ul>

--- a/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,10 +17,12 @@
     
     <p tal:omit-tag="textual">Ora che la tua candidatura è stata approvata, puoi accedere alla nostra piattaforma utilizzando lo pseudonimo e la password che ci hai fornito durante il processo di candidatura. Dopo aver effettuato il login, troverai:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">i link a tutte le applicazioni software a cui hai accesso diretto. Non è necessario effettuare di nuovo il login! Visita innanzitutto il nostro <a tal:attributes="href string:https://workspace.${domain_name}">spazio di lavoro</a>, dove si svolge la maggior parte della nostra attività;</li>
+        <li tal:omit-tag="textual">i link a tutte le applicazioni software a cui hai accesso diretto. Non è necessario effettuare di nuovo il login! Visita innanzitutto il nostro <a href="https://workspace.cosmopolitical.coop/login">spazio di lavoro</a>, dove si svolge la maggior parte della nostra attività;</li>
         <li tal:omit-tag="textual">un link al modulo in cui puoi visualizzare e modificare il tuo profilo. In questo modulo, ti invitiamo a presentarti agli altri membri della nostra Comunità con un breve "testo del profilo";</li>
         <li tal:omit-tag="textual">un link per effettuare il logout.</li>
     </ul>
+
+ <p tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR"> <strong>Non dimenticarlo!</strong> Per godere di tutti i tuoi diritti di Cooperatore, e in particolare per avere diritto di voto, devi: (1) <a href="https://www.cosmopolitical.coop/Share">acquistare almeno una quota della Cooperativa</a> e (2) <a href="https://www.cosmopolitical.coop/YearContrib">pagare la tua quota annuale</a>. Fallo il prima possibile!</p>
 
     <p tal:omit-tag="textual">Ecco gli elementi principali del tuo profilo che abbiamo registrato:</p>
     <ul tal:omit-tag="textual">

--- a/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -27,7 +27,7 @@
         <li tal:omit-tag="textual">il tuo pseudonimo: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Ti preghiamo di conservare con cura e in modo sicuro questo pseudonimo: è l'identificativo che userai durante tutta la tua attività sulla nostra piattaforma informatica;</li>
         <li tal:omit-tag="textual">la tua password: (la password che hai fornito al momento della registrazione);</li>
         <li tal:omit-tag="textual">il tuo indirizzo e-mail: (l'indirizzo e-mail a cui inviamo la presente e-mail);</li>
-        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">i tuoi dati di identità: (tutti i tuoi nomi e cognomi, la tua data di nascita, come forniti e verificati durante il processo di registrazione);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR">i tuoi dati di identità: (tutti i tuoi nomi e cognomi, la tua data di nascita, come forniti e verificati durante il processo di registrazione);</li>
         <li tal:omit-tag="textual">la tua lingua preferita per interagire con noi: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
         <li tal:omit-tag="textual">la seconda lingua che accetti che noi utilizziamo per interagire con te: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
         <li tal:omit-tag="textual">la lingua che accetti che noi utilizziamo, come terza scelta, per interagire con te: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>

--- a/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/it/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -4,44 +4,44 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:omit-tag="textual">
 <head tal:omit-tag="textual">
-    <title tal:omit-tag="textual">La tua richiesta di iscrizione alla <span tal:replace="domain_name">Site Name</span> è stata approvata</title>.
+    <title tal:omit-tag="textual">La tua richiesta di iscrizione alla piattaforma di <span tal:replace="domain_name">Site Name</span> è stata approvata</title>.
 </head>
 <body tal:omit-tag="textual">
 <h1 tal:omit-tag="textual">Congratulazioni per l'approvazione della tua Candidatura!</h1>
     
-    <p tal:omit-tag="textual">Ciao <span tal:replace="user" tal:condition="exists:user">Nome del Richiedente</span>,</p>
+    <p tal:omit-tag="textual">Ciao <span tal:replace="python:candidature.pseudonym">pseudonym</span>,</p>
     
-    <p tal:omit-tag="textual">Siamo lieti di informarti che la tua candidatura alla <span tal:replace="domain_name" >Nome del sito</span> per il ruolo di <span tal:replace="python:candidature.type">Role</span> è stata approvata.</p>
+    <p tal:omit-tag="textual">Siamo lieti di informarti che la tua candidatura alla piattaforma di <span tal:replace="domain_name" >Nome del sito</span> per il ruolo di <span tal:replace="python:candidature.type">Role</span> è stata approvata.</p>
     
-    <p tal:omit-tag=“textual”>Grazie per esserti unito a noi! Siamo felici di darti il benvenuto nella nostra Comunità.</p>
+    <p tal:omit-tag="textual">Grazie per esserti unito a noi! Siamo felici di darti il benvenuto nella nostra Comunità.</p>
     
-    <p tal:omit-tag=“textual”>Ora che la tua candidatura è stata approvata, puoi accedere alla nostra piattaforma utilizzando lo pseudonimo e la password che ci hai fornito durante il processo di candidatura. Dopo aver effettuato il login, troverai:</p>
-    <ul tal:omit-tag=“textual”>
-        <li tal:omit-tag=“textual”>i link a tutte le applicazioni software a cui hai accesso diretto. Non è necessario effettuare di nuovo il login!
-        <li tal:omit-tag=“textual”>un link al modulo in cui puoi visualizzare e modificare il tuo profilo. In questo modulo, ti invitiamo a presentarti agli altri membri della nostra Comunità con un breve “testo del profilo” e a mostrare una piccola immagine che ti rappresenti (il tuo “avatar”);</li>
-        <li tal:omit-tag=“textual”>un link per effettuare il logout.</li>
+    <p tal:omit-tag="textual">Ora che la tua candidatura è stata approvata, puoi accedere alla nostra piattaforma utilizzando lo pseudonimo e la password che ci hai fornito durante il processo di candidatura. Dopo aver effettuato il login, troverai:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">i link a tutte le applicazioni software a cui hai accesso diretto. Non è necessario effettuare di nuovo il login! Visita innanzitutto il nostro <a href="https://workspace.<span tal:replace="domain_name">nome di dominio</span>">spazio di lavoro</a>, dove si svolge la maggior parte della nostra attività;</li>
+        <li tal:omit-tag="textual">un link al modulo in cui puoi visualizzare e modificare il tuo profilo. In questo modulo, ti invitiamo a presentarti agli altri membri della nostra Comunità con un breve "testo del profilo";</li>
+        <li tal:omit-tag="textual">un link per effettuare il logout.</li>
     </ul>
 
-    <p tal:omit-tag=“textual”>Ecco gli elementi principali del tuo profilo che abbiamo registrato:</p>
-    <ul tal:omit-tag=“textual”>
-        <li tal:omit-tag=“textual”>il tuo pseudonimo: ##PSEUDONYM. Ti preghiamo di tenere un'attenta e sicura registrazione di questo pseudonimo: è l'unico identificativo con cui potrai accedere alla nostra piattaforma informatica;</li>
-        <li tal:omit-tag=“textual”>la tua password: (la password che hai fornito al momento della registrazione);</li>
-        <li tal:omit-tag=“textual”>il tuo indirizzo e-mail: (l'indirizzo e-mail a cui inviamo la presente e-mail);</li>
-        <li tal:omit-tag=“textual” tal:condition=“##IS_COOPERATOR”>i tuoi dati di identità: (tutti i tuoi nomi e cognomi, la tua data di nascita, come forniti e verificati durante il processo di registrazione);</li>
-        <li tal:omit-tag=“textual”>la tua lingua preferita per interagire con noi: ##LANGUAGE_1;</li>
-        <li tal:omit-tag=“textual”>la seconda lingua che accetti che noi utilizziamo per interagire con te: ##LANGUAGE_2;</li>
-        <li tal:omit-tag=“textual”>la lingua che accetti che noi utilizziamo, come terza scelta, per interagire con te: ##LANGUAGE_3.</li>
+    <p tal:omit-tag="textual">Ecco gli elementi principali del tuo profilo che abbiamo registrato:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">il tuo pseudonimo: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Ti preghiamo di conservare con cura e in modo sicuro questo pseudonimo: è l'identificativo che userai durante tutta la tua attività sulla nostra piattaforma informatica;</li>
+        <li tal:omit-tag="textual">la tua password: (la password che hai fornito al momento della registrazione);</li>
+        <li tal:omit-tag="textual">il tuo indirizzo e-mail: (l'indirizzo e-mail a cui inviamo la presente e-mail);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">i tuoi dati di identità: (tutti i tuoi nomi e cognomi, la tua data di nascita, come forniti e verificati durante il processo di registrazione);</li>
+        <li tal:omit-tag="textual">la tua lingua preferita per interagire con noi: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
+        <li tal:omit-tag="textual">la seconda lingua che accetti che noi utilizziamo per interagire con te: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
+        <li tal:omit-tag="textual">la lingua che accetti che noi utilizziamo, come terza scelta, per interagire con te: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>
         </ul>
 
-    <p tal:omit-tag=“textual”>Per tua informazione, ecco i dettagli relativi al completamento del processo di registrazione:</p>
-    <ul tal:omit-tag=“textual”>
-        <li tal:omit-tag=“textual”>ID di candidatura: <span tal:replace=“python:candidature.oid”>ID di candidatura</span></li>
-        <li tal:omit-tag=“textual”>Data di approvazione: <span tal:replace=“python:candidature.modifiche[-1]”>Ultima transizione</span></li>
-        <li tal:omit-tag=“textual”>Statuto: Approvato</li>
+    <p tal:omit-tag="textual">Per tua informazione, ecco i dettagli relativi al completamento del processo di registrazione:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">ID di candidatura: <span tal:replace="python:candidature.oid">ID di candidatura</span></li>
+        <li tal:omit-tag="textual">Data di approvazione: <span tal:replace="python:candidature.modifiche[-1]">Ultima transizione</span></li>
+        <li tal:omit-tag="textual">Statuto: Approvato</li>
     </ul>
 
     
-    <p tal:omit-tag=“textual”>Non vediamo l'ora di avere il piacere di lavorare insieme a te!</p>
+    <p tal:omit-tag="textual">Non vediamo l'ora di avere il piacere di lavorare insieme a te!</p>
     
     <p tal:omit-tag="textual">Buoni saluti,</p>
     <p tal:omit-tag="textual">Il team di <span tal:replace="domain_name">Nome del sito</span></p>

--- a/alirpunkto/locale/it/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/it/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:metal=“http://xml.zope.org/namespaces/metal”
+    xmlns:i18n=“http://xml.zope.org/namespaces/i18n”
+    xmlns:tal=“http://xml.zope.org/namespaces/tal”
+    
+tal:omit-tag=“textual”>
+<head tal:omit-tag=“textual”>
+    <title tal:omit-tag=‘textual’>La tua richiesta per il <span tal:replace=“domain_name”>nome di dominio</span> è stata respinta</title>
+</head>
+<body tal:omit-tag=“textual”>
+    <h1 tal:omit-tag=“textual”>Ci dispiace informarti che la tua candidatura è stata respinta</h1>
+    
+    <p tal:omit-tag=‘textual’>Ciao <span tal:replace=“python:candidature.pseudonym”>Nome del candidato</span>,</p>
+        <p tal:omit-tag=“textual”>Ci dispiace informarti che la tua candidatura al <span tal:replace=‘domain_name’>Nome di dominio</span> per il ruolo di <span tal:replace=“python:candidature.type”>Ruolo</span> è stata respinta. Il motivo è che la maggioranza dei verificatori ha ritenuto che le informazioni da te fornite sulla tua identità (nome e cognome, data di nascita) non corrispondessero a quelle dei tuoi documenti d’identità ufficiali, oppure che il tuo selfie recente non fosse sufficientemente simile alla foto presente sul tuo documento d’identità ufficiale. Se ritieni che si tratti di un errore, ti invitiamo a inviare nuovamente la tua candidatura, magari allegando copie più nitide dei tuoi documenti d’identità ufficiali o un selfie di qualità migliore.</p>
+    <p tal:omit-tag=“textual”>Siamo consapevoli della delusione e della frustrazione che questo rifiuto possa causarti, e ci scusiamo per questo. D’altra parte, ti invitiamo a considerare che il rigore del nostro processo di candidatura è necessario per garantire che il principio democratico “una persona, un voto” sia rispettato nella nostra Cooperativa, e che solo i cittadini dell’Unione Europea di età superiore ai 18 anni possano diventare Cooperatori. </p>
+
+<p tal:omit-tag=“textual”>Per tua informazione, ecco i dettagli relativi alla conclusione della tua procedura di registrazione:</p>
+    <ul tal:omit-tag=‘textual’>
+        <li tal:omit-tag=“textual”>ID candidatura: <span tal:replace=“python:candidature.oid”>ID della candidatura</span></li>
+        <li tal:omit-tag=‘textual’>Data di rifiuto: <span tal:replace=“python:candidature.modifications[-1]”>Ultima modifica</span></li>
+        <li tal:omit-tag=“textual”>Stato: Rifiutata</li>
+    
+</ul>
+
+    
+    <p tal:omit-tag=“textual”>Ci dispiace davvero tanto per la delusione che potremmo averti causato e ti inviamo i nostri </p>
+
+    
+    <p tal:omit-tag=“textual”>Cordiali saluti.</p>
+    
+<p tal:omit-tag=“textual”>Il team di <span tal:replace=“domain_name”>Nome dominio</span>.</p>
+    <p tal:omit-tag=‘textual’ tal:content=“organization_details”>Dettagli dell'organizzazione</p>
+</body>
+</html>

--- a/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,10 +17,12 @@
     
     <p tal:omit-tag="textual">Nu je aanmelding is goedgekeurd, kun je inloggen op ons platform met het pseudoniem en wachtwoord dat je tijdens de aanmeldprocedure hebt opgegeven. Nadat je bent ingelogd, vind je:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">de links naar alle softwaretoepassingen waartoe je direct toegang hebt. Je hoeft niet opnieuw in te loggen! Bezoek vooral onze <a tal:attributes="href string:https://workspace.${domain_name}">werkruimte</a>, waar het grootste deel van onze activiteiten plaatsvindt;</li>
+        <li tal:omit-tag="textual">de links naar alle softwaretoepassingen waartoe je direct toegang hebt. Je hoeft niet opnieuw in te loggen! Bezoek vooral onze <a href="https://workspace.cosmopolitical.coop/login">werkruimte</a>, waar het grootste deel van onze activiteiten plaatsvindt;</li>
         <li tal:omit-tag="textual">een link naar het formulier waar je je eigen profiel kunt bekijken en bewerken. Op dit formulier moedigen we je aan om jezelf te presenteren aan de andere leden van onze Gemeenschap in een korte "profieltekst";</li>
         <li tal:omit-tag="textual">een link om uit te loggen.</li>
     </ul>
+
+ <p tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR"> <strong>Vergeet het niet!</strong> Om van al je rechten als Coöperant te kunnen genieten, en met name om stemrecht te hebben, moet je: (1) <a href="https://www.cosmopolitical.coop/Share">minstens één aandeel in de Coöperatie kopen</a> en (2) <a href="https://www.cosmopolitical.coop/YearContrib">je jaarlijkse bijdrage betalen</a>. Doe dit zo snel mogelijk!</p>
 
     <p tal:omit-tag="textual">hier zijn de belangrijkste elementen van je profiel die we hebben vastgelegd:</p>
     <ul tal:omit-tag="textual">

--- a/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,7 +17,7 @@
     
     <p tal:omit-tag="textual">Nu je aanmelding is goedgekeurd, kun je inloggen op ons platform met het pseudoniem en wachtwoord dat je tijdens de aanmeldprocedure hebt opgegeven. Nadat je bent ingelogd, vind je:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">de links naar alle softwaretoepassingen waartoe je direct toegang hebt. Je hoeft niet opnieuw in te loggen! Bezoek vooral onze <a href="https://workspace.<span tal:replace="domain_name">Domeinnaam</span>">werkruimte</a>, waar het grootste deel van onze activiteiten plaatsvindt;</li>
+        <li tal:omit-tag="textual">de links naar alle softwaretoepassingen waartoe je direct toegang hebt. Je hoeft niet opnieuw in te loggen! Bezoek vooral onze <a tal:attributes="href string:https://workspace.${domain_name}">werkruimte</a>, waar het grootste deel van onze activiteiten plaatsvindt;</li>
         <li tal:omit-tag="textual">een link naar het formulier waar je je eigen profiel kunt bekijken en bewerken. Op dit formulier moedigen we je aan om jezelf te presenteren aan de andere leden van onze Gemeenschap in een korte "profieltekst";</li>
         <li tal:omit-tag="textual">een link om uit te loggen.</li>
     </ul>

--- a/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -27,7 +27,7 @@
         <li tal:omit-tag="textual">uw pseudoniem: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Bewaar dit pseudoniem zorgvuldig en veilig: het is de identificatiecode die je tijdens al je activiteiten op ons IT-platform zult gebruiken;</li>
         <li tal:omit-tag="textual">uw wachtwoord: (het wachtwoord dat je bij je registratie hebt opgegeven);</li>
         <li tal:omit-tag="textual">uw e-mailadres: (het e-mailadres waarnaar we deze e-mail sturen);</li>
-        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR">
 uw identiteitsgegevens: (al je voor- en achternamen, je geboortedatum, zoals opgegeven en geverifieerd tijdens je registratieproces);</li>
         <li tal:omit-tag="textual">uw voorkeurstaal om met u te communiceren: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
         <li tal:omit-tag="textual">de tweede taal die je accepteert dat we gebruiken om met je te communiceren: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>

--- a/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -4,43 +4,44 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:omit-tag="textual">
 <head tal:omit-tag="textual">
-    <title tal:omit-tag="textual">Uw aanvraag voor de <span tal:replace="domain_name" >Sitienaam</span> is goedgekeurd</title>.
+    <title tal:omit-tag="textual">Uw aanvraag voor het platform van <span tal:replace="domain_name" >Sitienaam</span> is goedgekeurd</title>.
 </head>
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">Gefeliciteerd met de goedkeuring van jouw aanvraag! </h1>
     
-    <p tal:omit-tag="textual">Hallo <span tal:replace="user" tal:condition="exists:user">Aanvragersnaam</span>,</p>
+    <p tal:omit-tag="textual">Hallo <span tal:replace="python:candidature.pseudonym">pseudonym</span>,</p>
     
-    <p tal:omit-tag="textual">Wij zijn verheugd je te informeren dat jouw aanvraag voor de <span tal:replace="domain_name">Site naam</span> voor de rol van <span tal:replace="python:candidature.type">Rol</span> is goedgekeurd.</p>
+    <p tal:omit-tag="textual">Wij zijn verheugd je te informeren dat jouw aanvraag voor het platform van <span tal:replace="domain_name">Site naam</span> voor de rol van <span tal:replace="python:candidature.type">Rol</span> is goedgekeurd.</p>
     
-    <p tal:omit-tag=“textual”>Bedankt dat je je bij ons hebt aangesloten! We zijn blij je te mogen verwelkomen in onze Gemeenschap.</p>
+    <p tal:omit-tag="textual">Bedankt dat je je bij ons hebt aangesloten! We zijn blij je te mogen verwelkomen in onze Gemeenschap.</p>
     
-    <p tal:omit-tag=“textual”>Nu je aanmelding is goedgekeurd, kun je inloggen op ons platform met het pseudoniem en wachtwoord dat je tijdens de aanmeldprocedure hebt opgegeven. Nadat je bent ingelogd, vind je:</p>
-    <ul tal:omit-tag=“textual”>
-        <li tal:omit-tag=“textual”>de links naar alle softwaretoepassingen waartoe je direct toegang hebt. Je hoeft niet opnieuw in te loggen!</li>
-        <li tal:omit-tag=“textual”>een link naar het formulier waar je je eigen profiel kunt bekijken en bewerken. Op dit formulier moedigen we je aan om jezelf te presenteren aan de andere leden van onze Gemeenschap in een korte “profieltekst” en om een kleine afbeelding weer te geven die jou voorstelt (je “avatar”);</li>
-        <li tal:omit-tag=“textual”>een link om uit te loggen.</li>
+    <p tal:omit-tag="textual">Nu je aanmelding is goedgekeurd, kun je inloggen op ons platform met het pseudoniem en wachtwoord dat je tijdens de aanmeldprocedure hebt opgegeven. Nadat je bent ingelogd, vind je:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">de links naar alle softwaretoepassingen waartoe je direct toegang hebt. Je hoeft niet opnieuw in te loggen! Bezoek vooral onze <a href="https://workspace.<span tal:replace="domain_name">Domeinnaam</span>">werkruimte</a>, waar het grootste deel van onze activiteiten plaatsvindt;</li>
+        <li tal:omit-tag="textual">een link naar het formulier waar je je eigen profiel kunt bekijken en bewerken. Op dit formulier moedigen we je aan om jezelf te presenteren aan de andere leden van onze Gemeenschap in een korte "profieltekst";</li>
+        <li tal:omit-tag="textual">een link om uit te loggen.</li>
     </ul>
 
-    <p tal:omit-tag=“textual”>hier zijn de belangrijkste elementen van je profiel die we hebben vastgelegd:</p>
-    <ul tal:omit-tag=“textual”>
-        <li tal:omit-tag=“textual”>uw pseudoniem: ##PSEUDONYM. Bewaar dit pseudoniem zorgvuldig en veilig: het is de enige identificatie waarmee je kunt inloggen op ons IT-platform;</li>
-        <li tal:omit-tag=“textual”>uw wachtwoord: (het wachtwoord dat je bij je registratie hebt opgegeven);</li>
-        <li tal:omit-tag=“textual”>uw e-mailadres: (het e-mailadres waarnaar we deze e-mail sturen);</li>
-        <li tal:omit-tag=“textual” tal:condition=“##IS_COOPERATOR”>uw identiteitsgegevens: (al je voor- en achternamen, je geboortedatum, zoals opgegeven en geverifieerd tijdens je registratieproces);</li>
-        <li tal:omit-tag=“textual”>uw voorkeurstaal om met u te communiceren: ##LANGUAGE_1;</li>
-        <li tal:omit-tag=“textual”>de tweede taal die je accepteert dat we gebruiken om met je te communiceren: ##LANGUAGE_2;</li>
-        <li tal:omit-tag=“textual”>de taal die je accepteert dat we, als derde keuze, gebruiken om met je te communiceren: ##LANGUAGE_3.</li>
+    <p tal:omit-tag="textual">hier zijn de belangrijkste elementen van je profiel die we hebben vastgelegd:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">uw pseudoniem: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Bewaar dit pseudoniem zorgvuldig en veilig: het is de identificatiecode die je tijdens al je activiteiten op ons IT-platform zult gebruiken;</li>
+        <li tal:omit-tag="textual">uw wachtwoord: (het wachtwoord dat je bij je registratie hebt opgegeven);</li>
+        <li tal:omit-tag="textual">uw e-mailadres: (het e-mailadres waarnaar we deze e-mail sturen);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">
+uw identiteitsgegevens: (al je voor- en achternamen, je geboortedatum, zoals opgegeven en geverifieerd tijdens je registratieproces);</li>
+        <li tal:omit-tag="textual">uw voorkeurstaal om met u te communiceren: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
+        <li tal:omit-tag="textual">de tweede taal die je accepteert dat we gebruiken om met je te communiceren: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
+        <li tal:omit-tag="textual">de taal die je accepteert dat we, als derde keuze, gebruiken om met je te communiceren: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>
         </ul>
 
-    <p tal:omit-tag=“textual”>Voor je administratie, hier zijn de details van de afronding van je registratieproces:</p>
-    <ul tal:omit-tag=“textual”>
-        <li tal:omit-tag=“textual”>Kandidatuur-ID: <span tal:replace=“python:candidature.oid”>Aanvraag-ID</span></li>
-        <li tal:omit-tag=“textual”>Goedkeuringsdatum: <span tal:replace=“python:candidature.modifications[-1]”>Laatste overgang</span></li>
-        <li tal:omit-tag=“textual”>Status: Goedgekeurd</li>
+    <p tal:omit-tag="textual">Voor je administratie, hier zijn de details van de afronding van je registratieproces:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">Kandidatuur-ID: <span tal:replace="python:candidature.oid">Aanvraag-ID</span></li>
+        <li tal:omit-tag="textual">Goedkeuringsdatum: <span tal:replace="python:candidature.modifications[-1]">Laatste overgang</span></li>
+        <li tal:omit-tag="textual">Status: Goedgekeurd</li>
     </ul>
     
-    <p tal:omit-tag=“textual”>Wij verheugen ons op de prettige samenwerking met jou! </p>
+    <p tal:omit-tag="textual">Wij verheugen ons op de prettige samenwerking met jou! </p>
     
     <p tal:omit-tag="textual">Gegroet, </p>
     <p tal:omit-tag="textual">Het team van <span tal:replace="domain_name" >Sitenaam</span></p>

--- a/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/nl/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    
+tal:omit-tag="textual">
+<head tal:omit-tag="textual">
+    <title tal:omit-tag=‘textual’>Je aanvraag voor de <span tal:replace="domain_name">domeinnaam</span> is afgewezen</title>
+</head>
+<body tal:omit-tag="textual">
+    <h1 tal:omit-tag="textual">Het spijt ons je te moeten meedelen dat je aanvraag is afgewezen</h1>
+    
+    <p tal:omit-tag=‘textual’>Hallo <span tal:replace="python:candidature.pseudonym">Naam van de aanvrager</span>,</p>
+        <p tal:omit-tag="textual">Helaas moeten we je laten weten dat je sollicitatie bij <span tal:replace=‘domain_name’>Domeinnaam</span> voor de functie van <span tal:replace="python:candidature.type">Functie</span> is afgewezen. De reden hiervoor is dat een meerderheid van de verificateurs van mening was dat de gegevens die je over je identiteit hebt verstrekt (voor- en achternaam, geboortedatum) niet overeenkwamen met die op je officiële identiteitsdocumenten, of dat je recente selfie niet voldoende overeenkwam met de foto op je officiële identiteitsdocument. Als je denkt dat dit een fout is, nodigen we je uit om je sollicitatie opnieuw in te dienen, eventueel met duidelijkere kopieën van je officiële identiteitsdocumenten of een betere selfie.</p>
+    <p tal:omit-tag="textual">We begrijpen dat deze afwijzing je teleurstelling en frustratie kan bezorgen, en bieden hiervoor onze excuses aan. Aan de andere kant vragen we je te bedenken dat de strenge aanpak van ons aanmeldingsproces nodig is om ervoor te zorgen dat het democratische principe ‘één persoon – één stem’ in onze Coöperatie wordt gerespecteerd, en dat alleen burgers van de Europese Unie die ouder zijn dan 18 jaar coöperanten mogen worden. </p>
+
+<p tal:omit-tag="textual">Ter informatie volgen hier de details van de afronding van je registratieproces:</p>
+    <ul tal:omit-tag=‘textual’>
+        <li tal:omit-tag="textual">Kandidatuur-ID: <span tal:replace="python:candidature.oid">Aanmeldings-ID</span></li>
+        <li tal:omit-tag=‘textual’>Datum afwijzing: <span tal:replace="python:candidature.modifications[-1]">Laatste wijziging</span></li>
+        <li tal:omit-tag="textual">Status: Afgewezen</li>
+    
+</ul>
+
+    
+    <p tal:omit-tag="textual">We vinden het nogmaals heel erg dat we je misschien teleurgesteld hebben, en sturen je onze </p>
+
+    
+    <p tal:omit-tag="textual">Vriendelijke groeten.</p>
+    
+<p tal:omit-tag="textual">Het team van <span tal:replace="domain_name">Domeinnaam</span>.</p>
+    <p tal:omit-tag=‘textual’ tal:content="organization_details">Organisatiegegevens</p>
+</body>
+</html>

--- a/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,7 +17,7 @@
     
     <p tal:omit-tag="textual">Teraz, gdy Twoja aplikacja została zatwierdzona, możesz zalogować się na naszej platformie przy użyciu pseudonimu i hasła podanych podczas procesu aplikacji. Po zalogowaniu znajdziesz:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">linki do wszystkich aplikacji, do których masz bezpośredni dostęp. Nie musisz logować się ponownie! Odwiedź przede wszystkim nasz <a href="https://workspace.<span tal:replace="domain_name„>nazwa domeny</span>">obszar roboczy</a>, gdzie toczy się większość naszej działalności;</li>.
+        <li tal:omit-tag="textual">linki do wszystkich aplikacji, do których masz bezpośredni dostęp. Nie musisz logować się ponownie! Odwiedź przede wszystkim nasz <a tal:attributes="href string:https://workspace.${domain_name}">obszar roboczy</a>, gdzie toczy się większość naszej działalności;</li>.
         <li tal:omit-tag="textual">link do formularza, w którym możesz przeglądać i edytować swój profil. W tym formularzu zachęcamy do zaprezentowania się innym członkom naszej społeczności w krótkim „tekście profilowym";</li>
         <li tal:omit-tag="textual"> link do wylogowania się.</li>
     </ul>

--- a/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -4,43 +4,43 @@
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     tal:omit-tag="textual">
 <head tal:omit-tag="textual">
-    <title tal:omit-tag="textual">Twoje zgłoszenie do witryny <span tal:replace="domain_name">Nazwa witryny</span> zostało zatwierdzone</title>
+    <title tal:omit-tag="textual">Twoje zgłoszenie do witryny na platformie <span tal:replace="domain_name">Nazwa witryny</span> zostało zatwierdzone</title>
 </head>
 <body tal:omit-tag="textual">
     <h1 tal:omit-tag="textual">Gratulujemy zatwierdzenia Twojego wniosku! </h1>
     
-    <p tal:omit-tag="textual">Witaj <span tal:replace="user" tal:condition="exists:user">Imię i nazwisko wnioskodawcy</span>,</p>
+    <p tal:omit-tag="textual">Witaj <span tal:replace="python:candidature.pseudonym">pseudonym</span>,</p>
     
     <p tal:omit-tag="textual">Z przyjemnością informujemy, że Twoja aplikacja na stanowisko <span tal:replace="domain_name">Nazwa witryny</span> dla roli <span tal:replace="python:candidature.type">Rola</span> została zatwierdzona.</p>
     
-    <p tal:omit-tag="textual”>Dziękujemy, że do nas dołączyłeś! Cieszymy się, że możemy powitać Cię w naszej społeczności.</p>
+    <p tal:omit-tag="textual">Dziękujemy, że do nas dołączyłeś! Cieszymy się, że możemy powitać Cię w naszej społeczności.</p>
     
-    <p tal:omit-tag="textual”>Teraz, gdy Twoja aplikacja została zatwierdzona, możesz zalogować się na naszej platformie przy użyciu pseudonimu i hasła podanych podczas procesu aplikacji. Po zalogowaniu znajdziesz:</p>
-    <ul tal:omit-tag="textual”>
-        <li tal:omit-tag="textual”>linki do wszystkich aplikacji, do których masz bezpośredni dostęp. Nie musisz logować się ponownie! </li>.
-        <li tal:omit-tag="textual”>link do formularza, w którym możesz przeglądać i edytować swój profil. W tym formularzu zachęcamy do zaprezentowania się innym członkom naszej społeczności w krótkim „tekście profilowym” i wyświetlenia małego zdjęcia, które Cię reprezentuje („awatar”);</li>
-        <li tal:omit-tag="textual”> link do wylogowania się.</li>
+    <p tal:omit-tag="textual">Teraz, gdy Twoja aplikacja została zatwierdzona, możesz zalogować się na naszej platformie przy użyciu pseudonimu i hasła podanych podczas procesu aplikacji. Po zalogowaniu znajdziesz:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">linki do wszystkich aplikacji, do których masz bezpośredni dostęp. Nie musisz logować się ponownie! Odwiedź przede wszystkim nasz <a href="https://workspace.<span tal:replace="domain_name„>nazwa domeny</span>">obszar roboczy</a>, gdzie toczy się większość naszej działalności;</li>.
+        <li tal:omit-tag="textual">link do formularza, w którym możesz przeglądać i edytować swój profil. W tym formularzu zachęcamy do zaprezentowania się innym członkom naszej społeczności w krótkim „tekście profilowym";</li>
+        <li tal:omit-tag="textual"> link do wylogowania się.</li>
     </ul>
 
-    <p tal:omit-tag="textual”>Oto główne elementy Twojego profilu, które zarejestrowaliśmy:</p>
-    <ul tal:omit-tag="textual”>
-        <li tal:omit-tag="textual”>Twój pseudonim: ##PSEUDONYM. Prosimy o UWAŻNE I BEZPIECZNE ZAPISANIE tego pseudonimu: jest to jedyny identyfikator, za pomocą którego możesz zalogować się do naszej platformy informatycznej;</li>
-        <li tal:omit-tag="textual”>Twoje hasło: (hasło, które podałeś podczas rejestracji);</li>
-        <li tal:omit-tag="textual”>Twój adres e-mail: (adres e-mail, na który wysyłamy niniejszą wiadomość e-mail);</li>
-        <li tal:omit-tag="textual” tal:condition="##IS_COOPERATOR”>Twoje dane identyfikacyjne: (wszystkie imiona i nazwiska, data urodzenia, podane i zweryfikowane podczas procesu rejestracji);</li>
-        <li tal:omit-tag="textual”>Twój preferowany język, w którym chcemy się z Tobą komunikować: ##LANGUAGE_1;</li>
-        <li tal:omit-tag="textual”>drugi język, który akceptujesz, abyśmy używali go do interakcji z Tobą: ##LANGUAGE_2;</li>
-        <li tal:omit-tag="textual”>język, który akceptujesz, a którego używamy jako trzeciego do interakcji z Tobą: ##LANGUAGE_3.</li>
+    <p tal:omit-tag="textual">Oto główne elementy Twojego profilu, które zarejestrowaliśmy:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">Twój pseudonim: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Proszę starannie i bezpiecznie zapisać ten pseudonim: to identyfikator, którego będziesz używać podczas całej swojej aktywności na naszej platformie IT;</li>
+        <li tal:omit-tag="textual">Twoje hasło: (hasło, które podałeś podczas rejestracji);</li>
+        <li tal:omit-tag="textual">Twój adres e-mail: (adres e-mail, na który wysyłamy niniejszą wiadomość e-mail);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">Twoje dane identyfikacyjne: (wszystkie imiona i nazwiska, data urodzenia, podane i zweryfikowane podczas procesu rejestracji);</li>
+        <li tal:omit-tag="textual">Twój preferowany język, w którym chcemy się z Tobą komunikować: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
+        <li tal:omit-tag="textual">drugi język, który akceptujesz, abyśmy używali go do interakcji z Tobą: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
+        <li tal:omit-tag="textual">język, który akceptujesz, a którego używamy jako trzeciego do interakcji z Tobą: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>
         </ul>
 
-    <p tal:omit-tag="textual”>Dla Twojej wiadomości, oto szczegóły finalizacji procesu rejestracji:</p>
-    <ul tal:omit-tag="textual”>
-        <li tal:omit-tag="textual”>Identyfikator kandydata: <span tal:replace="python:candidature.oid”>Identyfikator aplikacji</span></li>
-        <li tal:omit-tag="textual”>Data zatwierdzenia: <span tal:replace="python:candidature.modifications[-1]”>Ostatnie przejście</span></li>
-        <li tal:omit-tag="textual”>Status: Zatwierdzony</li>
+    <p tal:omit-tag="textual">Dla Twojej wiadomości, oto szczegóły finalizacji procesu rejestracji:</p>
+    <ul tal:omit-tag="textual">
+        <li tal:omit-tag="textual">Identyfikator kandydata: <span tal:replace="python:candidature.oid">Identyfikator aplikacji</span></li>
+        <li tal:omit-tag="textual">Data zatwierdzenia: <span tal:replace="python:candidature.modifications[-1]">Ostatnie przejście</span></li>
+        <li tal:omit-tag="textual">Status: Zatwierdzony</li>
     </ul>
     
-    <p tal:omit-tag="textual”>Z niecierpliwością czekamy na przyjemność współpracy z Tobą! </p>
+    <p tal:omit-tag="textual">Z niecierpliwością czekamy na przyjemność współpracy z Tobą! </p>
     
     <p tal:omit-tag="textual">Z wyrazami szacunku,</p>
     <p tal:omit-tag="textual">Zespół <span tal:replace="domain_name">Nazwa strony</span></p>

--- a/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -17,10 +17,12 @@
     
     <p tal:omit-tag="textual">Teraz, gdy Twoja aplikacja została zatwierdzona, możesz zalogować się na naszej platformie przy użyciu pseudonimu i hasła podanych podczas procesu aplikacji. Po zalogowaniu znajdziesz:</p>
     <ul tal:omit-tag="textual">
-        <li tal:omit-tag="textual">linki do wszystkich aplikacji, do których masz bezpośredni dostęp. Nie musisz logować się ponownie! Odwiedź przede wszystkim nasz <a tal:attributes="href string:https://workspace.${domain_name}">obszar roboczy</a>, gdzie toczy się większość naszej działalności;</li>.
-        <li tal:omit-tag="textual">link do formularza, w którym możesz przeglądać i edytować swój profil. W tym formularzu zachęcamy do zaprezentowania się innym członkom naszej społeczności w krótkim „tekście profilowym";</li>
+        <li tal:omit-tag="textual">linki do wszystkich aplikacji, do których masz bezpośredni dostęp. Nie musisz logować się ponownie! Odwiedź przede wszystkim nasz <a href="https://workspace.cosmopolitical.coop/login">obszar roboczy</a>, gdzie toczy się większość naszej działalności;</li>.
+        <li tal:omit-tag="textual">link do formularza, w którym możesz przeglądać i edytować swój profil. W tym formularzu zachęcamy do zaprezentowania się innym członkom naszej społeczności w krótkim "tekście profilowym";</li>
         <li tal:omit-tag="textual"> link do wylogowania się.</li>
     </ul>
+
+ <p tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR"> <strong>Nie zapomnij!</strong> Żeby móc korzystać ze wszystkich praw jako członek spółdzielni, a zwłaszcza żeby mieć prawo do głosowania, musisz: (1) <a href="https://www.cosmopolitical.coop/Share">kupić co najmniej jeden udział w Spółdzielni</a> oraz (2) <a href="https://www.cosmopolitical.coop/YearContrib">opłacić roczną składkę</a>. Zrób to jak najszybciej!</p>
 
     <p tal:omit-tag="textual">Oto główne elementy Twojego profilu, które zarejestrowaliśmy:</p>
     <ul tal:omit-tag="textual">

--- a/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
+++ b/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_approuved_email.pt
@@ -27,7 +27,7 @@
         <li tal:omit-tag="textual">Twój pseudonim: <span tal:replace="python:candidature.pseudonym">pseudonym</span>. Proszę starannie i bezpiecznie zapisać ten pseudonim: to identyfikator, którego będziesz używać podczas całej swojej aktywności na naszej platformie IT;</li>
         <li tal:omit-tag="textual">Twoje hasło: (hasło, które podałeś podczas rejestracji);</li>
         <li tal:omit-tag="textual">Twój adres e-mail: (adres e-mail, na który wysyłamy niniejszą wiadomość e-mail);</li>
-        <li tal:omit-tag="textual" tal:condition="python:candidature.type=MemberTypes.COOPERATOR">Twoje dane identyfikacyjne: (wszystkie imiona i nazwiska, data urodzenia, podane i zweryfikowane podczas procesu rejestracji);</li>
+        <li tal:omit-tag="textual" tal:condition="python:candidature.type==MemberTypes.COOPERATOR">Twoje dane identyfikacyjne: (wszystkie imiona i nazwiska, data urodzenia, podane i zweryfikowane podczas procesu rejestracji);</li>
         <li tal:omit-tag="textual">Twój preferowany język, w którym chcemy się z Tobą komunikować: <span tal:replace="python:candidature.lang1">Language_1</span>;</li>
         <li tal:omit-tag="textual">drugi język, który akceptujesz, abyśmy używali go do interakcji z Tobą: <span tal:replace="python:candidature.lang2">Language_2</span>;</li>
         <li tal:omit-tag="textual">język, który akceptujesz, a którego używamy jako trzeciego do interakcji z Tobą: <span tal:replace="python:candidature.lang3">Language_3</span>.</li>

--- a/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_rejected_email.pt
+++ b/alirpunkto/locale/pl/LC_MESSAGES/send_candidature_rejected_email.pt
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    
+tal:omit-tag="textual">
+<head tal:omit-tag="textual">
+    <title tal:omit-tag=»textual«>Twój wniosek dotyczący <span tal:replace="domain_name">nazwy domeny</span> został odrzucony</title>
+</head>
+<body tal:omit-tag="textual">
+    <h1 tal:omit-tag="textual">Z przykrością informujemy o odrzuceniu Twojego wniosku</h1>
+    
+    <p tal:omit-tag=»textual«>Cześć <span tal:replace="python:candidature.pseudonym">Imię wnioskodawcy</span>,</p>
+        <p tal:omit-tag="textual">Z przykrością informujemy, że Twój wniosek złożony na stronie <span tal:replace=»domain_name«>Nazwa domeny</span> o objęcie stanowiska <span tal:replace="python:candidature.type">Stanowisko</span> został odrzucony. Powodem jest to, że większość weryfikatorów uznała, że podane przez ciebie dane osobowe (imię i nazwisko, data urodzenia) nie zgadzają się z danymi z twoich oficjalnych dokumentów tożsamości albo że twoje aktualne selfie nie jest wystarczająco podobne do zdjęcia w twoim oficjalnym dokumencie tożsamości. Jeśli uważasz, że to pomyłka, zapraszamy cię do ponownego złożenia podania, na przykład z wyraźniejszymi kopiami oficjalnych dokumentów tożsamości lub lepszym zdjęciem selfie.</p>
+    <p tal:omit-tag="textual">Zdajemy sobie sprawę z rozczarowania i frustracji, jakie może wywołać u ciebie ta odmowa, i przepraszamy za to. Z drugiej strony prosimy, abyś wziął pod uwagę, że rygorystyczny proces weryfikacji jest niezbędny, aby zapewnić przestrzeganie w naszej Spółdzielni demokratycznej zasady "jedna osoba – jeden głos" oraz aby tylko obywatele Unii Europejskiej w wieku powyżej 18 lat mogli zostać członkami Spółdzielni. </p>
+
+<p tal:omit-tag="textual">Dla Twojej wiadomości, oto szczegóły dotyczące zakończenia procesu rejestracji:</p>
+    <ul tal:omit-tag=»textual«>
+        <li tal:omit-tag="textual">Identyfikator kandydatury: <span tal:replace="python:candidature.oid">ID zgłoszenia</span></li>
+        <li tal:omit-tag=»textual«>Data odrzucenia: <span tal:replace="python:candidature.modifications[-1]">Ostatnia zmiana</span></li>
+        <li tal:omit-tag="textual">Status: Odrzucone</li>
+    
+</ul>
+
+    
+    <p tal:omit-tag="textual">Jeszcze raz szczerze przepraszamy za rozczarowanie, jakie mogliśmy Ci sprawić, i przesyłamy Ci nasze </p>
+
+    
+    <p tal:omit-tag="textual">Pozdrowienia.</p>
+    
+<p tal:omit-tag="textual">Zespół <span tal:replace="domain_name">Domain Name</span>.</p>
+    <p tal:omit-tag=»textual« tal:content="organization_details">Dane organizacji</p>
+</body>
+</html>

--- a/alirpunkto/views/register.py
+++ b/alirpunkto/views/register.py
@@ -596,7 +596,7 @@ def handle_confirmed_human_state(request, candidature):
                 template_vars = {
                     'candidature': candidature,
                     'domain_name': domain_name,
-                    'organization_details': organization_details,                    
+                    'organization_details': organization_details                   
                     }
                 send_result = send_email(
                     request,

--- a/alirpunkto/views/register.py
+++ b/alirpunkto/views/register.py
@@ -540,7 +540,7 @@ def handle_confirmed_human_state(request, candidature):
             parameters[field_name] = value
         # @TODO use permission than member type to manipulate the data
         if candidature.type == MemberTypes.COOPERATOR:
-            # Extract birthdate from request only for coopereator
+            # Extract birthdate from request only for cooperator
             # This is a bit convoluted because of the way deform handles nested forms
             start_birthdate = False
             birthdate = None
@@ -594,12 +594,9 @@ def handle_confirmed_human_state(request, candidature):
             # Send FINAL e-mail
                 template_path = "alirpunkto:templates/send_candidature_approuved_email.pt"
                 template_vars = {
-                    #@TODO Complement the list of variables
                     'candidature': candidature,
-                    'site_name': site_name,
                     'domain_name': domain_name,
-                    'organization_details': organization_details,
-                    'voting_url': request.route_url('vote', _query={'oid': candidature.oid}),
+                    'organization_details': organization_details,                    
                     }
                 send_result = send_email(
                     request,

--- a/alirpunkto/views/register.py
+++ b/alirpunkto/views/register.py
@@ -590,6 +590,32 @@ def handle_confirmed_human_state(request, candidature):
                 candidatures.monitored_members.pop(candidature.oid, None)
                 candidature.candidature_state = CandidatureStates.APPROVED
                 email_template = "send_candidature_approuved_email"
+# ADDITIONS BY VIBE - START
+            # Send FINAL e-mail
+                template_path = "alirpunkto:templates/send_candidature_approuved_email.pt"
+                template_vars = {
+                    #@TODO Complement the list of variables
+                    'candidature': candidature,
+                    'site_name': site_name,
+                    'domain_name': domain_name,
+                    'organization_details': organization_details,
+                    'voting_url': request.route_url('vote', _query={'oid': candidature.oid}),
+                    }
+                send_result = send_email(
+                    request,
+                    subject="",
+                    recipients=[candidature.email],
+                    template_path=template_path,
+                    template_vars=template_vars,
+                    derive_subject_from_title=True
+                    )
+                if send_result:
+                    candidature.add_email_send_status(EmailSendStatus.SENT, "send_candidature_approuved_email")
+                    transaction.commit()
+                else:
+                    candidature.add_email_send_status(EmailSendStatus.ERROR, "send_candidature_approuved_email")
+                    transaction.abort()
+# ADDITIONS BY VIBE - END
             case MemberTypes.COOPERATOR:
                 candidature.candidature_state = CandidatureStates.UNIQUE_DATA
                 email_template = "send_candidature_pending_email"

--- a/alirpunkto/views/vote.py
+++ b/alirpunkto/views/vote.py
@@ -16,6 +16,7 @@ from alirpunkto.models.member import (
 from alirpunkto.utils import (
     get_candidatures,
     send_confirm_validation_email,
+    send_email,
     send_candidature_state_change_email,
     register_user_to_ldap
 )
@@ -149,6 +150,36 @@ def vote_view(request):
                 )
                 # send email to the candidature owner
                 email_template = "send_candidature_approuved_email"
+                send_candidature_state_change_email(
+                request,
+                candidature)
+# ADDITIONS BY VIBE - START
+            # Send FINAL e-mail
+                template_path = "alirpunkto:templates/send_candidature_approuved_email.pt"
+                template_vars = {
+                    #@TODO Complement the list of variables
+                    'candidature': candidature,
+                    'site_name': site_name,
+                    'domain_name': domain_name,
+                    'organization_details': organization_details,
+                    'voting_url': request.route_url('vote', _query={'oid': candidature.oid}),
+                    }
+                send_result = send_email(
+                    request,
+                    subject="",
+                    recipients=[candidature.email],
+                    template_path=template_path,
+                    template_vars=template_vars,
+                    derive_subject_from_title=True
+                    )
+                if send_result:
+                    candidature.add_email_send_status(EmailSendStatus.SENT, "send_candidature_approuved_email")
+                    transaction.commit()
+                else:
+                    candidature.add_email_send_status(EmailSendStatus.ERROR, "send_candidature_approuved_email")
+                    transaction.abort()
+# ADDITIONS BY VIBE - END
+            
             else:
                 candidature.candidature_state = CandidatureStates.REFUSED
                 candidature.add_email_send_status(
@@ -156,12 +187,35 @@ def vote_view(request):
                     "send_candidature_rejected_email"
                 )
                 email_template = "send_candidature_rejected_email"
-            # send email to the candidature owner
-            send_candidature_state_change_email(
+                send_candidature_state_change_email(
                 request,
-                candidature,
-                email_template
-            )
+                candidature)
+# ADDITIONS BY VIBE - START
+            # Send FINAL e-mail
+                template_path = "alirpunkto:templates/send_candidature_rejected_email.pt"
+                template_vars = {
+                    #@TODO Complement the list of variables
+                    'candidature': candidature,
+                    'site_name': site_name,
+                    'domain_name': domain_name,
+                    'organization_details': organization_details,
+                    'voting_url': request.route_url('vote', _query={'oid': candidature.oid}),
+                    }
+                send_result = send_email(
+                    request,
+                    subject="",
+                    recipients=[candidature.email],
+                    template_path=template_path,
+                    template_vars=template_vars,
+                    derive_subject_from_title=True
+                    )
+                if send_result:
+                    candidature.add_email_send_status(EmailSendStatus.SENT, "send_candidature_approuved_email")
+                    transaction.commit()
+                else:
+                    candidature.add_email_send_status(EmailSendStatus.ERROR, "send_candidature_approuved_email")
+                    transaction.abort()
+# ADDITIONS BY VIBE - END            
             try:
                 candidature.add_email_send_status(EmailSendStatus.SENT, email_template)
             except Exception as e:
@@ -196,6 +250,7 @@ def vote_view(request):
         #@TODO if date is passed, compute the result with the votes
 
         #@TODO send email to the candidature owner
+    
 
     return {
         'logged_in': True if user else False,

--- a/alirpunkto/views/vote.py
+++ b/alirpunkto/views/vote.py
@@ -157,12 +157,9 @@ def vote_view(request):
             # Send FINAL e-mail
                 template_path = "alirpunkto:templates/send_candidature_approuved_email.pt"
                 template_vars = {
-                    #@TODO Complement the list of variables
-                    'candidature': candidature,
-                    'site_name': site_name,
+                   'candidature': candidature,
                     'domain_name': domain_name,
-                    'organization_details': organization_details,
-                    'voting_url': request.route_url('vote', _query={'oid': candidature.oid}),
+                    'organization_details': organization_details
                     }
                 send_result = send_email(
                     request,
@@ -194,12 +191,9 @@ def vote_view(request):
             # Send FINAL e-mail
                 template_path = "alirpunkto:templates/send_candidature_rejected_email.pt"
                 template_vars = {
-                    #@TODO Complement the list of variables
                     'candidature': candidature,
-                    'site_name': site_name,
                     'domain_name': domain_name,
-                    'organization_details': organization_details,
-                    'voting_url': request.route_url('vote', _query={'oid': candidature.oid}),
+                    'organization_details': organization_details
                     }
                 send_result = send_email(
                     request,


### PR DESCRIPTION
Should create and send the final e-mails informing the applicant that his/her candidature as a Cooperator or as an Ordinary Member has been approved or rejected.

v2 of the pull request includes the creation of the **send_candidature_rejected_email.pt** template for the main translation languages (de, en, es, fr, it, nl, pl) and the fine-tuning of the **send_candidature_approuved_email.pt** template in these languages

Should address issues #213 and #214